### PR TITLE
fix: Support integer enums

### DIFF
--- a/end_to_end_tests/fastapi_app/openapi.json
+++ b/end_to_end_tests/fastapi_app/openapi.json
@@ -64,6 +64,14 @@
                         },
                         "name": "some_date",
                         "in": "query"
+                    },
+                    {
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/IntegerEnum"
+                        },
+                        "name": "some_integer",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -602,6 +610,15 @@
                         }
                     }
                 }
+            },
+            "IntegerEnum": {
+                "title": "IntegerEnum",
+                "enum": [
+                    1,
+                    2,
+                    -3
+                ],
+                "description": "An integer enum."
             },
             "ValidationError": {
                 "title": "ValidationError",

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -8,6 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.a_model import AModel
 from ...models.an_enum import AnEnum
 from ...models.http_validation_error import HTTPValidationError
+from ...models.integer_enum import IntegerEnum
 from ...types import Response
 
 
@@ -16,6 +17,7 @@ def _get_kwargs(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
+    some_integer: IntegerEnum,
 ) -> Dict[str, Any]:
     url = "{}/tests/".format(client.base_url)
 
@@ -33,9 +35,12 @@ def _get_kwargs(
     else:
         json_some_date = some_date.isoformat()
 
+    json_some_integer = some_integer.value
+
     params: Dict[str, Any] = {
         "an_enum_value": json_an_enum_value,
         "some_date": json_some_date,
+        "some_integer": json_some_integer,
     }
 
     return {
@@ -69,11 +74,13 @@ def sync_detailed(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
+    some_integer: IntegerEnum,
 ) -> Response[Union[List[AModel], HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         an_enum_value=an_enum_value,
         some_date=some_date,
+        some_integer=some_integer,
     )
 
     response = httpx.get(
@@ -88,6 +95,7 @@ def sync(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
+    some_integer: IntegerEnum,
 ) -> Optional[Union[List[AModel], HTTPValidationError]]:
     """ Get a list of things  """
 
@@ -95,6 +103,7 @@ def sync(
         client=client,
         an_enum_value=an_enum_value,
         some_date=some_date,
+        some_integer=some_integer,
     ).parsed
 
 
@@ -103,11 +112,13 @@ async def asyncio_detailed(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
+    some_integer: IntegerEnum,
 ) -> Response[Union[List[AModel], HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         an_enum_value=an_enum_value,
         some_date=some_date,
+        some_integer=some_integer,
     )
 
     async with httpx.AsyncClient() as _client:
@@ -121,6 +132,7 @@ async def asyncio(
     client: Client,
     an_enum_value: List[AnEnum],
     some_date: Union[datetime.date, datetime.datetime],
+    some_integer: IntegerEnum,
 ) -> Optional[Union[List[AModel], HTTPValidationError]]:
     """ Get a list of things  """
 
@@ -129,5 +141,6 @@ async def asyncio(
             client=client,
             an_enum_value=an_enum_value,
             some_date=some_date,
+            some_integer=some_integer,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
@@ -5,4 +5,5 @@ from .an_enum import AnEnum
 from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from .different_enum import DifferentEnum
 from .http_validation_error import HTTPValidationError
+from .integer_enum import IntegerEnum
 from .validation_error import ValidationError

--- a/end_to_end_tests/golden-record/my_test_api_client/models/integer_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/integer_enum.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class IntegerEnum(str, Enum):
+    VALUE_0 = 1
+    VALUE_1 = 2
+    VALUE_2 = -3

--- a/openapi_python_client/parser/properties.py
+++ b/openapi_python_client/parser/properties.py
@@ -338,14 +338,14 @@ class EnumProperty(Property):
         output: Dict[str, str] = {}
 
         for i, value in enumerate(values):
-            if type(value) is str and value[0].isalpha():
+            if isinstance(value, str) and value[0].isalpha():
                 key = value.upper()
             else:
                 key = f"VALUE_{i}"
             if key in output:
                 raise ValueError(f"Duplicate key {key} in Enum")
             sanitized_key = utils.fix_keywords(utils.sanitize(key))
-            if type(value) is str:
+            if isinstance(value, str):
                 value = utils.remove_string_escapes(value)
             output[sanitized_key] = repr(value)
 

--- a/openapi_python_client/parser/properties.py
+++ b/openapi_python_client/parser/properties.py
@@ -284,7 +284,7 @@ _existing_enums: Dict[str, EnumProperty] = {}
 class EnumProperty(Property):
     """ A property that should use an enum """
 
-    values: Dict[str, str]
+    values: Dict[str, Any]
     reference: Reference = field(init=False)
     title: InitVar[str]
 
@@ -333,19 +333,21 @@ class EnumProperty(Property):
         return imports
 
     @staticmethod
-    def values_from_list(values: List[str]) -> Dict[str, str]:
+    def values_from_list(values: List[Any]) -> Dict[str, Any]:
         """ Convert a list of values into dict of {name: value} """
         output: Dict[str, str] = {}
 
         for i, value in enumerate(values):
-            if value[0].isalpha():
+            if type(value) is str and value[0].isalpha():
                 key = value.upper()
             else:
                 key = f"VALUE_{i}"
             if key in output:
                 raise ValueError(f"Duplicate key {key} in Enum")
             sanitized_key = utils.fix_keywords(utils.sanitize(key))
-            output[sanitized_key] = utils.remove_string_escapes(value)
+            if type(value) is str:
+                value = utils.remove_string_escapes(value)
+            output[sanitized_key] = repr(value)
 
         return output
 

--- a/openapi_python_client/templates/enum.pyi
+++ b/openapi_python_client/templates/enum.pyi
@@ -2,5 +2,5 @@ from enum import Enum
 
 class {{ enum.reference.class_name }}(str, Enum):
     {% for key, value in enum.values.items() %}
-    {{ key }} = "{{ value }}"
+    {{ key }} = {{ value }}
     {% endfor %}

--- a/tests/test_openapi_parser/test_properties.py
+++ b/tests/test_openapi_parser/test_properties.py
@@ -427,15 +427,23 @@ class TestEnumProperty:
     def test_values_from_list(self):
         from openapi_python_client.parser.properties import EnumProperty
 
-        data = ["abc", "123", "a23", "1bc"]
+        string_data = ["abc", "123", "a23", "1bc"]
+        integer_data = [1, 2, 345]
 
-        result = EnumProperty.values_from_list(data)
+        string_result = EnumProperty.values_from_list(string_data)
+        integer_result = EnumProperty.values_from_list(integer_data)
 
-        assert result == {
-            "ABC": "abc",
-            "VALUE_1": "123",
-            "A23": "a23",
-            "VALUE_3": "1bc",
+        assert string_result == {
+            "ABC": "'abc'",
+            "VALUE_1": "'123'",
+            "A23": "'a23'",
+            "VALUE_3": "'1bc'",
+        }
+
+        assert integer_result == {
+            "VALUE_0": "1",
+            "VALUE_1": "2",
+            "VALUE_2": "345"
         }
 
     def test_values_from_list_duplicate(self):


### PR DESCRIPTION
## Description
Previously, schema enums only actually supported string type values, though according to the [spec](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.5.5.1), values may be of any type. This fix adds support for non-string types in general, with the specific goal of supporting integer values in schema enums. 

## Test plan
- Modified the end-to-end tests to add an integer enum to the spec, which is then generated into client code. Ensured the enum was generated properly, and that existing enums' behavior was not changed. 
- Modified a test for the helper function `EnumProperty.values_from_list` to also operate on integer values, and ensured that the result is as expected.