### PR TITLE
fix: Bugfixes, tests for allOf functionality BNCH-15425

### DIFF
--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -250,7 +250,7 @@ class Model:
             if required:
                 self.required_properties.append(p)
                 if p in self.optional_properties:
-                    self.optional_properties.pop(p)
+                    self.optional_properties.remove(p)
             elif p not in self.optional_properties:
                 self.optional_properties.append(p)
             self.relative_imports.update(p.get_imports(prefix=".."))

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -281,6 +281,7 @@ class Model:
                     references += [sub_prop]
                 else:
                     all_props.update(sub_prop.properties)
+                    required_set.update(sub_prop.required or [])
 
         for key, value in all_props.items():
             required = key in required_set

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -229,7 +229,6 @@ class Model:
     def resolve_references(self, schemas):
         required_set = set()
         props = {}
-        print(self.reference.class_name, self.references)
         while self.references:
             reference = self.references.pop()
             prop = schemas[Reference.from_ref(reference.ref).class_name]
@@ -254,7 +253,7 @@ class Model:
                     self.optional_properties.pop(p)
             elif p not in self.optional_properties:
                 self.optional_properties.append(p)
-            self.relative_imports.update(p.get_imports(prefix=""))
+            self.relative_imports.update(p.get_imports(prefix=".."))
 
         return self.required_properties + self.optional_properties
 

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -220,7 +220,7 @@ class Model:
     """
 
     reference: Reference
-    references: List[Reference]
+    references: List[oai.Reference]
     required_properties: List[Property]
     optional_properties: List[Property]
     description: str

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -249,9 +249,9 @@ class Model:
                 return p
             if required:
                 self.required_properties.append(p)
-                if p in self.optional_properties:
-                    self.optional_properties.remove(p)
-            elif p not in self.optional_properties:
+                # Remove the optional version
+                self.optional_properties = [op for op in self.optional_properties if op.name != p.name]
+            elif not any(ep for ep in (self.optional_properties + self.required_properties) if ep.name == p.name):
                 self.optional_properties.append(p)
             self.relative_imports.update(p.get_imports(prefix=".."))
 

--- a/tests/test_openapi_parser/test_openapi.py
+++ b/tests/test_openapi_parser/test_openapi.py
@@ -71,21 +71,23 @@ class TestModel:
     def test_from_data(self, mocker):
         from openapi_python_client.parser.properties import Property
 
+        required_property = mocker.MagicMock(autospec=Property)
+        required_property.allOf = None
+        required_imports = mocker.MagicMock()
+        required_property.get_imports.return_value = {required_imports}
+        optional_property = mocker.MagicMock(autospec=Property)
+        optional_property.allOf = None
+        optional_imports = mocker.MagicMock()
+        optional_property.get_imports.return_value = {optional_imports}
         in_data = oai.Schema.construct(
             title=mocker.MagicMock(),
             description=mocker.MagicMock(),
             required=["RequiredEnum"],
             properties={
-                "RequiredEnum": mocker.MagicMock(),
-                "OptionalDateTime": mocker.MagicMock(),
+                "RequiredEnum": required_property,
+                "OptionalDateTime": optional_property,
             },
         )
-        required_property = mocker.MagicMock(autospec=Property)
-        required_imports = mocker.MagicMock()
-        required_property.get_imports.return_value = {required_imports}
-        optional_property = mocker.MagicMock(autospec=Property)
-        optional_imports = mocker.MagicMock()
-        optional_property.get_imports.return_value = {optional_imports}
         property_from_data = mocker.patch(
             f"{MODULE_NAME}.property_from_data",
             side_effect=[required_property, optional_property],
@@ -107,6 +109,7 @@ class TestModel:
         optional_property.get_imports.assert_called_once_with(prefix="..")
         assert result == Model(
             reference=from_ref(),
+            references=[],
             required_properties=[required_property],
             optional_properties=[optional_property],
             relative_imports={
@@ -117,14 +120,17 @@ class TestModel:
         )
 
     def test_from_data_property_parse_error(self, mocker):
+        from openapi_python_client.parser.properties import Property
+
+        required_property = mocker.MagicMock(autospec=Property)
+        required_property.allOf = None
+        optional_property = mocker.MagicMock(autospec=Property)
+        optional_property.allOf = None
         in_data = oai.Schema.construct(
             title=mocker.MagicMock(),
             description=mocker.MagicMock(),
             required=["RequiredEnum"],
-            properties={
-                "RequiredEnum": mocker.MagicMock(),
-                "OptionalDateTime": mocker.MagicMock(),
-            },
+            properties={"RequiredEnum": required_property, "OptionalDateTime": optional_property},
         )
         parse_error = ParseError(data=mocker.MagicMock())
         property_from_data = mocker.patch(

--- a/tests/test_openapi_parser/test_openapi.py
+++ b/tests/test_openapi_parser/test_openapi.py
@@ -150,6 +150,57 @@ class TestModel:
 
         assert result == parse_error
 
+    def test_resolve_references(self, mocker):
+
+        schemas = {
+            "RefA": oai.Schema.construct(
+                title=mocker.MagicMock(),
+                description=mocker.MagicMock(),
+                required=["String"],
+                properties={
+                    "String": oai.Schema.construct(type="string"),
+                    "Enum": oai.Schema.construct(type="string", enum=["aValue"]),
+                    "DateTime": oai.Schema.construct(type="string", format="date-time"),
+                },
+            ),
+            "RefB": oai.Schema.construct(
+                title=mocker.MagicMock(),
+                description=mocker.MagicMock(),
+                required=["DateTime"],
+                properties={
+                    "Int": oai.Schema.construct(type="integer"),
+                    "DateTime": oai.Schema.construct(type="string", format="date-time"),
+                    "Float": oai.Schema.construct(type="number", format="float")
+                },
+            ),
+        }
+
+        model_schema = oai.Schema.construct(
+            allOf=[
+                oai.Reference.construct(ref="#/components/schemas/RefA"),
+                oai.Reference.construct(ref="#/components/schemas/RefB"),
+                oai.Schema.construct(
+                    title=mocker.MagicMock(),
+                    description=mocker.MagicMock(),
+                    required=["Float"],
+                    properties={
+                        "String": oai.Schema.construct(type="string"),
+                        "Float": oai.Schema.construct(type="number", format="float"),
+                    },
+                ),
+            ]
+        )
+
+        from openapi_python_client.parser.openapi import Model
+
+        model = Model.from_data(data=model_schema, name="Model")
+        model.resolve_references(schemas)
+        print(f"{model=}")
+        assert sorted(p.name for p in model.required_properties) == ["DateTime", "Float", "String"]
+        assert all(p.required for p in model.required_properties)
+        assert sorted(p.name for p in model.optional_properties) == ["Enum", "Int"]
+        assert all(not p.required for p in model.optional_properties)
+
 
 class TestSchemas:
     def test_build(self, mocker):
@@ -165,6 +216,8 @@ class TestSchemas:
         result = Schemas.build(schemas=in_data)
 
         from_data.assert_has_calls([mocker.call(data=value, name=name) for (name, value) in in_data.items()])
+        schema_1.resolve_references.assert_called_once_with(in_data)
+        schema_2.resolve_references.assert_called_once_with(in_data)
         assert result == Schemas(
             models={
                 schema_1.reference.class_name: schema_1,


### PR DESCRIPTION
## Description
- In `resolve_references` - account for the fact tha we can't compare optional and required properties with `==` as they are `dataclass`es and the `required` value is different
- Combine required property list for `allOf`s elements that are schemas
- Fixes tests in the [`allof`](https://github.com/benchling/openapi-python-client/tree/allof) branch
- Adds new test for `Model.resolve_references` and ensures `resolve_references` is called by `Schemas.build`


## Test Plan
Tests pass