### PR TITLE
Bug fix for allOf with no properties

### DIFF
--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -279,7 +279,7 @@ class Model:
             for sub_prop in data.allOf:
                 if isinstance(sub_prop, oai.Reference):
                     references += [sub_prop]
-                else:
+                elif sub_prop.properties:
                     all_props.update(sub_prop.properties)
                     required_set.update(sub_prop.required or [])
 

--- a/tests/test_openapi_parser/test_openapi.py
+++ b/tests/test_openapi_parser/test_openapi.py
@@ -173,12 +173,18 @@ class TestModel:
                     "Float": oai.Schema.construct(type="number", format="float")
                 },
             ),
+            # Intentionally no properties defined
+            "RefC": oai.Schema.construct(
+                title=mocker.MagicMock(),
+                description=mocker.MagicMock(),
+            ),
         }
 
         model_schema = oai.Schema.construct(
             allOf=[
                 oai.Reference.construct(ref="#/components/schemas/RefA"),
                 oai.Reference.construct(ref="#/components/schemas/RefB"),
+                oai.Reference.construct(ref="#/components/schemas/RefC"),
                 oai.Schema.construct(
                     title=mocker.MagicMock(),
                     description=mocker.MagicMock(),
@@ -195,7 +201,6 @@ class TestModel:
 
         model = Model.from_data(data=model_schema, name="Model")
         model.resolve_references(schemas)
-        print(f"{model=}")
         assert sorted(p.name for p in model.required_properties) == ["DateTime", "Float", "String"]
         assert all(p.required for p in model.required_properties)
         assert sorted(p.name for p in model.optional_properties) == ["Enum", "Int"]


### PR DESCRIPTION
## Description

When generating a client against the updated `Request` specs, I encountered an issue when an object is defined without properties. For example:

```
    UserSummary:
      allOf:
        - $ref: '#/components/schemas/PartySummary'
        - example:
            id: ent_a0SApq3z
            handle: lpasteur
            name: Louis Pasteur
```

This fixes and adds an appropriate test.

## Test Plan

- Unit tests
- Generate a client successfully against the updated `Requests` spec

## Additional Context
