### PR TITLE
feat: Change from_dict from staticmethod to classmethod BNCH-17564

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import attr
 from dateutil.parser import isoparse
@@ -7,6 +7,8 @@ from dateutil.parser import isoparse
 from ..models.an_enum import AnEnum
 from ..models.different_enum import DifferentEnum
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AModel")
 
 
 @attr.s(auto_attribs=True)
@@ -75,8 +77,8 @@ class AModel:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "AModel":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         an_enum_value = AnEnum(d.pop("an_enum_value"))
 
@@ -124,7 +126,7 @@ class AModel:
 
         not_required_not_nullable = d.pop("not_required_not_nullable", UNSET)
 
-        a_model = AModel(
+        a_model = cls(
             an_enum_value=an_enum_value,
             a_camel_date_time=a_camel_date_time,
             a_date=a_date,

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/body_upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/body_upload_file_tests_upload_post.py
@@ -1,9 +1,11 @@
 from io import BytesIO
-from typing import Any, Dict
+from typing import Any, Dict, Type, TypeVar
 
 import attr
 
 from ..types import File
+
+T = TypeVar("T", bound="BodyUploadFileTestsUploadPost")
 
 
 @attr.s(auto_attribs=True)
@@ -24,12 +26,12 @@ class BodyUploadFileTestsUploadPost:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "BodyUploadFileTestsUploadPost":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         some_file = File(payload=BytesIO(d.pop("some_file")))
 
-        body_upload_file_tests_upload_post = BodyUploadFileTestsUploadPost(
+        body_upload_file_tests_upload_post = cls(
             some_file=some_file,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/free_form_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/free_form_model.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
+
+T = TypeVar("T", bound="FreeFormModel")
 
 
 @attr.s(auto_attribs=True)
@@ -17,10 +19,10 @@ class FreeFormModel:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "FreeFormModel":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        free_form_model = FreeFormModel()
+        free_form_model = cls()
 
         free_form_model.additional_properties = d
         return free_form_model

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/http_validation_error.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/http_validation_error.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 
 from ..models.validation_error import ValidationError
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="HTTPValidationError")
 
 
 @attr.s(auto_attribs=True)
@@ -28,8 +30,8 @@ class HTTPValidationError:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "HTTPValidationError":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         detail = []
         _detail = d.pop("detail", UNSET)
@@ -38,7 +40,7 @@ class HTTPValidationError:
 
             detail.append(detail_item)
 
-        http_validation_error = HTTPValidationError(
+        http_validation_error = cls(
             detail=detail,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_additional_properties_inlined.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_additional_properties_inlined.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 
@@ -6,6 +6,8 @@ from ..models.model_with_additional_properties_inlined_additional_property impor
     ModelWithAdditionalPropertiesInlinedAdditionalProperty,
 )
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithAdditionalPropertiesInlined")
 
 
 @attr.s(auto_attribs=True)
@@ -30,12 +32,12 @@ class ModelWithAdditionalPropertiesInlined:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAdditionalPropertiesInlined":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_number = d.pop("a_number", UNSET)
 
-        model_with_additional_properties_inlined = ModelWithAdditionalPropertiesInlined(
+        model_with_additional_properties_inlined = cls(
             a_number=a_number,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_additional_properties_inlined_additional_property.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_additional_properties_inlined_additional_property.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithAdditionalPropertiesInlinedAdditionalProperty")
 
 
 @attr.s(auto_attribs=True)
@@ -23,15 +25,13 @@ class ModelWithAdditionalPropertiesInlinedAdditionalProperty:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAdditionalPropertiesInlinedAdditionalProperty":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         extra_props_prop = d.pop("extra_props_prop", UNSET)
 
-        model_with_additional_properties_inlined_additional_property = (
-            ModelWithAdditionalPropertiesInlinedAdditionalProperty(
-                extra_props_prop=extra_props_prop,
-            )
+        model_with_additional_properties_inlined_additional_property = cls(
+            extra_props_prop=extra_props_prop,
         )
 
         model_with_additional_properties_inlined_additional_property.additional_properties = d

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_additional_properties_refed.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_additional_properties_refed.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
 from ..models.an_enum import AnEnum
+
+T = TypeVar("T", bound="ModelWithAdditionalPropertiesRefed")
 
 
 @attr.s(auto_attribs=True)
@@ -21,10 +23,10 @@ class ModelWithAdditionalPropertiesRefed:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAdditionalPropertiesRefed":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_additional_properties_refed = ModelWithAdditionalPropertiesRefed()
+        model_with_additional_properties_refed = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_any_json_properties.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_any_json_properties.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
 import attr
 
 from ..models.model_with_any_json_properties_additional_property import ModelWithAnyJsonPropertiesAdditionalProperty
 from ..types import Unset
+
+T = TypeVar("T", bound="ModelWithAnyJsonProperties")
 
 
 @attr.s(auto_attribs=True)
@@ -31,10 +33,10 @@ class ModelWithAnyJsonProperties:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAnyJsonProperties":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_any_json_properties = ModelWithAnyJsonProperties()
+        model_with_any_json_properties = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_any_json_properties_additional_property.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_any_json_properties_additional_property.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
+
+T = TypeVar("T", bound="ModelWithAnyJsonPropertiesAdditionalProperty")
 
 
 @attr.s(auto_attribs=True)
@@ -17,10 +19,10 @@ class ModelWithAnyJsonPropertiesAdditionalProperty:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAnyJsonPropertiesAdditionalProperty":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_any_json_properties_additional_property = ModelWithAnyJsonPropertiesAdditionalProperty()
+        model_with_any_json_properties_additional_property = cls()
 
         model_with_any_json_properties_additional_property.additional_properties = d
         return model_with_any_json_properties_additional_property

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
 import attr
 
@@ -6,6 +6,8 @@ from ..models.model_with_primitive_additional_properties_a_date_holder import (
     ModelWithPrimitiveAdditionalPropertiesADateHolder,
 )
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithPrimitiveAdditionalProperties")
 
 
 @attr.s(auto_attribs=True)
@@ -28,8 +30,8 @@ class ModelWithPrimitiveAdditionalProperties:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithPrimitiveAdditionalProperties":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_date_holder: Union[ModelWithPrimitiveAdditionalPropertiesADateHolder, Unset] = UNSET
         _a_date_holder = d.pop("a_date_holder", UNSET)
@@ -38,7 +40,7 @@ class ModelWithPrimitiveAdditionalProperties:
                 cast(Dict[str, Any], _a_date_holder)
             )
 
-        model_with_primitive_additional_properties = ModelWithPrimitiveAdditionalProperties(
+        model_with_primitive_additional_properties = cls(
             a_date_holder=a_date_holder,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties_a_date_holder.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties_a_date_holder.py
@@ -1,8 +1,10 @@
 import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 from dateutil.parser import isoparse
+
+T = TypeVar("T", bound="ModelWithPrimitiveAdditionalPropertiesADateHolder")
 
 
 @attr.s(auto_attribs=True)
@@ -21,10 +23,10 @@ class ModelWithPrimitiveAdditionalPropertiesADateHolder:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithPrimitiveAdditionalPropertiesADateHolder":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_primitive_additional_properties_a_date_holder = ModelWithPrimitiveAdditionalPropertiesADateHolder()
+        model_with_primitive_additional_properties_a_date_holder = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_union_property.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_union_property.py
@@ -1,10 +1,12 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import attr
 
 from ..models.an_enum import AnEnum
 from ..models.an_int_enum import AnIntEnum
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithUnionProperty")
 
 
 @attr.s(auto_attribs=True)
@@ -34,8 +36,8 @@ class ModelWithUnionProperty:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithUnionProperty":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
 
         def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
@@ -59,7 +61,7 @@ class ModelWithUnionProperty:
 
         a_property = _parse_a_property(d.pop("a_property", UNSET))
 
-        model_with_union_property = ModelWithUnionProperty(
+        model_with_union_property = cls(
             a_property=a_property,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_json_body.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_json_body.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import attr
 
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TestInlineObjectsJsonBody")
 
 
 @attr.s(auto_attribs=True)
@@ -21,12 +23,12 @@ class TestInlineObjectsJsonBody:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "TestInlineObjectsJsonBody":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_property = d.pop("a_property", UNSET)
 
-        test_inline_objects_json_body = TestInlineObjectsJsonBody(
+        test_inline_objects_json_body = cls(
             a_property=a_property,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_response_200.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/test_inline_objects_response_200.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import attr
 
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TestInlineObjectsResponse_200")
 
 
 @attr.s(auto_attribs=True)
@@ -21,12 +23,12 @@ class TestInlineObjectsResponse_200:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "TestInlineObjectsResponse_200":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_property = d.pop("a_property", UNSET)
 
-        test_inline_objects_response_200 = TestInlineObjectsResponse_200(
+        test_inline_objects_response_200 = cls(
             a_property=a_property,
         )
 

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/validation_error.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/validation_error.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Type, TypeVar, cast
 
 import attr
+
+T = TypeVar("T", bound="ValidationError")
 
 
 @attr.s(auto_attribs=True)
@@ -28,8 +30,8 @@ class ValidationError:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ValidationError":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         loc = cast(List[str], d.pop("loc"))
 
@@ -37,7 +39,7 @@ class ValidationError:
 
         type = d.pop("type")
 
-        validation_error = ValidationError(
+        validation_error = cls(
             loc=loc,
             msg=msg,
             type=type,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import attr
 from dateutil.parser import isoparse
@@ -7,6 +7,8 @@ from dateutil.parser import isoparse
 from ..models.an_enum import AnEnum
 from ..models.different_enum import DifferentEnum
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AModel")
 
 
 @attr.s(auto_attribs=True)
@@ -75,8 +77,8 @@ class AModel:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "AModel":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         an_enum_value = AnEnum(d.pop("an_enum_value"))
 
@@ -124,7 +126,7 @@ class AModel:
 
         not_required_not_nullable = d.pop("not_required_not_nullable", UNSET)
 
-        a_model = AModel(
+        a_model = cls(
             an_enum_value=an_enum_value,
             a_camel_date_time=a_camel_date_time,
             a_date=a_date,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/body_upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/body_upload_file_tests_upload_post.py
@@ -1,9 +1,11 @@
 from io import BytesIO
-from typing import Any, Dict
+from typing import Any, Dict, Type, TypeVar
 
 import attr
 
 from ..types import File
+
+T = TypeVar("T", bound="BodyUploadFileTestsUploadPost")
 
 
 @attr.s(auto_attribs=True)
@@ -24,12 +26,12 @@ class BodyUploadFileTestsUploadPost:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "BodyUploadFileTestsUploadPost":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         some_file = File(payload=BytesIO(d.pop("some_file")))
 
-        body_upload_file_tests_upload_post = BodyUploadFileTestsUploadPost(
+        body_upload_file_tests_upload_post = cls(
             some_file=some_file,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/free_form_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/free_form_model.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
+
+T = TypeVar("T", bound="FreeFormModel")
 
 
 @attr.s(auto_attribs=True)
@@ -17,10 +19,10 @@ class FreeFormModel:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "FreeFormModel":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        free_form_model = FreeFormModel()
+        free_form_model = cls()
 
         free_form_model.additional_properties = d
         return free_form_model

--- a/end_to_end_tests/golden-record/my_test_api_client/models/http_validation_error.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/http_validation_error.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 
 from ..models.validation_error import ValidationError
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="HTTPValidationError")
 
 
 @attr.s(auto_attribs=True)
@@ -28,8 +30,8 @@ class HTTPValidationError:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "HTTPValidationError":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         detail = []
         _detail = d.pop("detail", UNSET)
@@ -38,7 +40,7 @@ class HTTPValidationError:
 
             detail.append(detail_item)
 
-        http_validation_error = HTTPValidationError(
+        http_validation_error = cls(
             detail=detail,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_inlined.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_inlined.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 
@@ -6,6 +6,8 @@ from ..models.model_with_additional_properties_inlined_additional_property impor
     ModelWithAdditionalPropertiesInlinedAdditionalProperty,
 )
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithAdditionalPropertiesInlined")
 
 
 @attr.s(auto_attribs=True)
@@ -30,12 +32,12 @@ class ModelWithAdditionalPropertiesInlined:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAdditionalPropertiesInlined":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_number = d.pop("a_number", UNSET)
 
-        model_with_additional_properties_inlined = ModelWithAdditionalPropertiesInlined(
+        model_with_additional_properties_inlined = cls(
             a_number=a_number,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_inlined_additional_property.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_inlined_additional_property.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithAdditionalPropertiesInlinedAdditionalProperty")
 
 
 @attr.s(auto_attribs=True)
@@ -23,15 +25,13 @@ class ModelWithAdditionalPropertiesInlinedAdditionalProperty:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAdditionalPropertiesInlinedAdditionalProperty":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         extra_props_prop = d.pop("extra_props_prop", UNSET)
 
-        model_with_additional_properties_inlined_additional_property = (
-            ModelWithAdditionalPropertiesInlinedAdditionalProperty(
-                extra_props_prop=extra_props_prop,
-            )
+        model_with_additional_properties_inlined_additional_property = cls(
+            extra_props_prop=extra_props_prop,
         )
 
         model_with_additional_properties_inlined_additional_property.additional_properties = d

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_refed.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_refed.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
 from ..models.an_enum import AnEnum
+
+T = TypeVar("T", bound="ModelWithAdditionalPropertiesRefed")
 
 
 @attr.s(auto_attribs=True)
@@ -21,10 +23,10 @@ class ModelWithAdditionalPropertiesRefed:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAdditionalPropertiesRefed":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_additional_properties_refed = ModelWithAdditionalPropertiesRefed()
+        model_with_additional_properties_refed = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_any_json_properties.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_any_json_properties.py
@@ -1,9 +1,11 @@
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
 import attr
 
 from ..models.model_with_any_json_properties_additional_property import ModelWithAnyJsonPropertiesAdditionalProperty
 from ..types import Unset
+
+T = TypeVar("T", bound="ModelWithAnyJsonProperties")
 
 
 @attr.s(auto_attribs=True)
@@ -31,10 +33,10 @@ class ModelWithAnyJsonProperties:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAnyJsonProperties":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_any_json_properties = ModelWithAnyJsonProperties()
+        model_with_any_json_properties = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_any_json_properties_additional_property.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_any_json_properties_additional_property.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
+
+T = TypeVar("T", bound="ModelWithAnyJsonPropertiesAdditionalProperty")
 
 
 @attr.s(auto_attribs=True)
@@ -17,10 +19,10 @@ class ModelWithAnyJsonPropertiesAdditionalProperty:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithAnyJsonPropertiesAdditionalProperty":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_any_json_properties_additional_property = ModelWithAnyJsonPropertiesAdditionalProperty()
+        model_with_any_json_properties_additional_property = cls()
 
         model_with_any_json_properties_additional_property.additional_properties = d
         return model_with_any_json_properties_additional_property

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
 import attr
 
@@ -6,6 +6,8 @@ from ..models.model_with_primitive_additional_properties_a_date_holder import (
     ModelWithPrimitiveAdditionalPropertiesADateHolder,
 )
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithPrimitiveAdditionalProperties")
 
 
 @attr.s(auto_attribs=True)
@@ -28,8 +30,8 @@ class ModelWithPrimitiveAdditionalProperties:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithPrimitiveAdditionalProperties":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_date_holder: Union[ModelWithPrimitiveAdditionalPropertiesADateHolder, Unset] = UNSET
         _a_date_holder = d.pop("a_date_holder", UNSET)
@@ -38,7 +40,7 @@ class ModelWithPrimitiveAdditionalProperties:
                 cast(Dict[str, Any], _a_date_holder)
             )
 
-        model_with_primitive_additional_properties = ModelWithPrimitiveAdditionalProperties(
+        model_with_primitive_additional_properties = cls(
             a_date_holder=a_date_holder,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties_a_date_holder.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties_a_date_holder.py
@@ -1,8 +1,10 @@
 import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 from dateutil.parser import isoparse
+
+T = TypeVar("T", bound="ModelWithPrimitiveAdditionalPropertiesADateHolder")
 
 
 @attr.s(auto_attribs=True)
@@ -21,10 +23,10 @@ class ModelWithPrimitiveAdditionalPropertiesADateHolder:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithPrimitiveAdditionalPropertiesADateHolder":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        model_with_primitive_additional_properties_a_date_holder = ModelWithPrimitiveAdditionalPropertiesADateHolder()
+        model_with_primitive_additional_properties_a_date_holder = cls()
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_union_property.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_union_property.py
@@ -1,10 +1,12 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import attr
 
 from ..models.an_enum import AnEnum
 from ..models.an_int_enum import AnIntEnum
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ModelWithUnionProperty")
 
 
 @attr.s(auto_attribs=True)
@@ -34,8 +36,8 @@ class ModelWithUnionProperty:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ModelWithUnionProperty":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
 
         def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
@@ -59,7 +61,7 @@ class ModelWithUnionProperty:
 
         a_property = _parse_a_property(d.pop("a_property", UNSET))
 
-        model_with_union_property = ModelWithUnionProperty(
+        model_with_union_property = cls(
             a_property=a_property,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_json_body.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_json_body.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import attr
 
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TestInlineObjectsJsonBody")
 
 
 @attr.s(auto_attribs=True)
@@ -21,12 +23,12 @@ class TestInlineObjectsJsonBody:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "TestInlineObjectsJsonBody":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_property = d.pop("a_property", UNSET)
 
-        test_inline_objects_json_body = TestInlineObjectsJsonBody(
+        test_inline_objects_json_body = cls(
             a_property=a_property,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_response_200.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/test_inline_objects_response_200.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Type, TypeVar, Union
 
 import attr
 
 from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TestInlineObjectsResponse_200")
 
 
 @attr.s(auto_attribs=True)
@@ -21,12 +23,12 @@ class TestInlineObjectsResponse_200:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "TestInlineObjectsResponse_200":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         a_property = d.pop("a_property", UNSET)
 
-        test_inline_objects_response_200 = TestInlineObjectsResponse_200(
+        test_inline_objects_response_200 = cls(
             a_property=a_property,
         )
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/validation_error.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/validation_error.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Type, TypeVar, cast
 
 import attr
+
+T = TypeVar("T", bound="ValidationError")
 
 
 @attr.s(auto_attribs=True)
@@ -28,8 +30,8 @@ class ValidationError:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "ValidationError":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
         loc = cast(List[str], d.pop("loc"))
 
@@ -37,7 +39,7 @@ class ValidationError:
 
         type = d.pop("type")
 
-        validation_error = ValidationError(
+        validation_error = cls(
             loc=loc,
             msg=msg,
             type=type,

--- a/openapi_python_client/templates/model.pyi
+++ b/openapi_python_client/templates/model.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, TypeVar, Type
 
 {% if model.additional_properties %}
 from typing import List
@@ -17,6 +17,8 @@ from ..types import UNSET, Unset
 {% if model.additional_properties %}
 {% set additional_property_type = 'Any' if model.additional_properties == True else model.additional_properties.get_type_string() %}
 {% endif %}
+
+T = TypeVar("T", bound="{{ model.reference.class_name }}")
 
 @attr.s(auto_attribs=True)
 class {{ model.reference.class_name }}:
@@ -72,8 +74,8 @@ class {{ model.reference.class_name }}:
 
         return field_dict
 
-    @staticmethod
-    def from_dict(src_dict: Dict[str, Any]) -> "{{ model.reference.class_name }}":
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
 {% for property in model.required_properties + model.optional_properties %}
     {% if property.required %}
@@ -89,7 +91,7 @@ class {{ model.reference.class_name }}:
     {% endif %}
 
 {% endfor %}
-        {{model.reference.module_name}} = {{ model.reference.class_name }}(
+        {{model.reference.module_name}} = cls(
 {% for property in model.required_properties + model.optional_properties %}
             {{ property.python_name }}={{ property.python_name }},
 {% endfor %}

--- a/openapi_python_client/templates/model.pyi
+++ b/openapi_python_client/templates/model.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TypeVar, Type
+from typing import Any, Dict, Type, TypeVar
 
 {% if model.additional_properties %}
 from typing import List

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openapi-python-client"
-version = "0.7.3"
+version = "0.7.4"
 description = "Generate modern Python clients from OpenAPI"
 repository = "https://github.com/triaxtec/openapi-python-client"
 license = "MIT"


### PR DESCRIPTION
This allows `from_dict` to be inherited and overridden by subclasses. I couldn't think of any scenarios where this would be a breaking change, unless someone was relying on incorrect subclass inheritance.

The only relevant changes are `model.pyi` and `pyproject.toml`. The rest of the files are from regenerating the `e2e` test.

## Test Plan
`poetry run mypy ~/openapi-python-client/end_to_end_tests/golden-record-custom/custom_e2e/models/`