### PR TITLE
fix: Fix optional model properties BNCH-20284

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/__init__.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/__init__.py
@@ -1,6 +1,10 @@
 """ Contains all the data models used in inputs/outputs """
 
 from .a_model import AModel
+from .a_model_model import AModelModel
+from .a_model_not_required_model import AModelNotRequiredModel
+from .a_model_not_required_nullable_model import AModelNotRequiredNullableModel
+from .a_model_nullable_model import AModelNullableModel
 from .an_enum import AnEnum
 from .an_int_enum import AnIntEnum
 from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model.py
@@ -4,6 +4,10 @@ from typing import Any, Dict, List, Optional, Union, cast
 import attr
 from dateutil.parser import isoparse
 
+from ..models.a_model_model import AModelModel
+from ..models.a_model_not_required_model import AModelNotRequiredModel
+from ..models.a_model_not_required_nullable_model import AModelNotRequiredNullableModel
+from ..models.a_model_nullable_model import AModelNullableModel
 from ..models.an_enum import AnEnum
 from ..models.different_enum import DifferentEnum
 from ..types import UNSET, Unset
@@ -17,12 +21,16 @@ class AModel:
     a_camel_date_time: Union[datetime.datetime, datetime.date]
     a_date: datetime.date
     required_not_nullable: str
+    model: AModelModel
     a_nullable_date: Optional[datetime.date]
     required_nullable: Optional[str]
+    nullable_model: Optional[AModelNullableModel]
     nested_list_of_enums: Union[Unset, List[List[DifferentEnum]]] = UNSET
     attr_1_leading_digit: Union[Unset, str] = UNSET
     not_required_nullable: Union[Unset, Optional[str]] = UNSET
     not_required_not_nullable: Union[Unset, str] = UNSET
+    not_required_model: Union[AModelNotRequiredModel, Unset] = UNSET
+    not_required_nullable_model: Union[Optional[AModelNotRequiredNullableModel], Unset] = UNSET
 
     def to_dict(self) -> Dict[str, Any]:
         an_enum_value = self.an_enum_value.value
@@ -35,6 +43,8 @@ class AModel:
 
         a_date = self.a_date.isoformat()
         required_not_nullable = self.required_not_nullable
+        model = self.model.to_dict()
+
         nested_list_of_enums: Union[Unset, List[Any]] = UNSET
         if not isinstance(self.nested_list_of_enums, Unset):
             nested_list_of_enums = []
@@ -52,6 +62,17 @@ class AModel:
         required_nullable = self.required_nullable
         not_required_nullable = self.not_required_nullable
         not_required_not_nullable = self.not_required_not_nullable
+        nullable_model = self.nullable_model.to_dict() if self.nullable_model else None
+
+        not_required_model: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.not_required_model, Unset):
+            not_required_model = self.not_required_model.to_dict()
+
+        not_required_nullable_model: Union[None, Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.not_required_nullable_model, Unset):
+            not_required_nullable_model = (
+                self.not_required_nullable_model.to_dict() if self.not_required_nullable_model else None
+            )
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(
@@ -60,8 +81,10 @@ class AModel:
                 "aCamelDateTime": a_camel_date_time,
                 "a_date": a_date,
                 "required_not_nullable": required_not_nullable,
+                "model": model,
                 "a_nullable_date": a_nullable_date,
                 "required_nullable": required_nullable,
+                "nullable_model": nullable_model,
             }
         )
         if nested_list_of_enums is not UNSET:
@@ -72,6 +95,10 @@ class AModel:
             field_dict["not_required_nullable"] = not_required_nullable
         if not_required_not_nullable is not UNSET:
             field_dict["not_required_not_nullable"] = not_required_not_nullable
+        if not_required_model is not UNSET:
+            field_dict["not_required_model"] = not_required_model
+        if not_required_nullable_model is not UNSET:
+            field_dict["not_required_nullable_model"] = not_required_nullable_model
 
         return field_dict
 
@@ -99,6 +126,8 @@ class AModel:
 
         required_not_nullable = d.pop("required_not_nullable")
 
+        model = AModelModel.from_dict(d.pop("model"))
+
         nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
         for nested_list_of_enums_item_data in _nested_list_of_enums or []:
@@ -124,17 +153,38 @@ class AModel:
 
         not_required_not_nullable = d.pop("not_required_not_nullable", UNSET)
 
+        nullable_model = None
+        _nullable_model = d.pop("nullable_model")
+        if _nullable_model is not None:
+            nullable_model = AModelNullableModel.from_dict(cast(Dict[str, Any], _nullable_model))
+
+        not_required_model: Union[AModelNotRequiredModel, Unset] = UNSET
+        _not_required_model = d.pop("not_required_model", UNSET)
+        if not isinstance(_not_required_model, Unset):
+            not_required_model = AModelNotRequiredModel.from_dict(cast(Dict[str, Any], _not_required_model))
+
+        not_required_nullable_model = None
+        _not_required_nullable_model = d.pop("not_required_nullable_model", UNSET)
+        if _not_required_nullable_model is not None and not isinstance(_not_required_nullable_model, Unset):
+            not_required_nullable_model = AModelNotRequiredNullableModel.from_dict(
+                cast(Dict[str, Any], _not_required_nullable_model)
+            )
+
         a_model = AModel(
             an_enum_value=an_enum_value,
             a_camel_date_time=a_camel_date_time,
             a_date=a_date,
             required_not_nullable=required_not_nullable,
+            model=model,
             nested_list_of_enums=nested_list_of_enums,
             a_nullable_date=a_nullable_date,
             attr_1_leading_digit=attr_1_leading_digit,
             required_nullable=required_nullable,
             not_required_nullable=not_required_nullable,
             not_required_not_nullable=not_required_not_nullable,
+            nullable_model=nullable_model,
+            not_required_model=not_required_model,
+            not_required_nullable_model=not_required_nullable_model,
         )
 
         return a_model

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_model = AModelModel(
+            a_property=a_property,
+        )
+
+        a_model_model.additional_properties = d
+        return a_model_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_not_required_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_not_required_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelNotRequiredModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelNotRequiredModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_not_required_model = AModelNotRequiredModel(
+            a_property=a_property,
+        )
+
+        a_model_not_required_model.additional_properties = d
+        return a_model_not_required_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_not_required_nullable_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_not_required_nullable_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelNotRequiredNullableModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelNotRequiredNullableModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_not_required_nullable_model = AModelNotRequiredNullableModel(
+            a_property=a_property,
+        )
+
+        a_model_not_required_nullable_model.additional_properties = d
+        return a_model_not_required_nullable_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_nullable_model.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/a_model_nullable_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelNullableModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelNullableModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_nullable_model = AModelNullableModel(
+            a_property=a_property,
+        )
+
+        a_model_nullable_model.additional_properties = d
+        return a_model_nullable_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/models/model_with_primitive_additional_properties.py
@@ -33,7 +33,7 @@ class ModelWithPrimitiveAdditionalProperties:
         d = src_dict.copy()
         a_date_holder: Union[ModelWithPrimitiveAdditionalPropertiesADateHolder, Unset] = UNSET
         _a_date_holder = d.pop("a_date_holder", UNSET)
-        if _a_date_holder is not None and not isinstance(_a_date_holder, Unset):
+        if not isinstance(_a_date_holder, Unset):
             a_date_holder = ModelWithPrimitiveAdditionalPropertiesADateHolder.from_dict(
                 cast(Dict[str, Any], _a_date_holder)
             )

--- a/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
@@ -1,6 +1,10 @@
 """ Contains all the data models used in inputs/outputs """
 
 from .a_model import AModel
+from .a_model_model import AModelModel
+from .a_model_not_required_model import AModelNotRequiredModel
+from .a_model_not_required_nullable_model import AModelNotRequiredNullableModel
+from .a_model_nullable_model import AModelNullableModel
 from .an_enum import AnEnum
 from .an_int_enum import AnIntEnum
 from .body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
@@ -4,6 +4,10 @@ from typing import Any, Dict, List, Optional, Union, cast
 import attr
 from dateutil.parser import isoparse
 
+from ..models.a_model_model import AModelModel
+from ..models.a_model_not_required_model import AModelNotRequiredModel
+from ..models.a_model_not_required_nullable_model import AModelNotRequiredNullableModel
+from ..models.a_model_nullable_model import AModelNullableModel
 from ..models.an_enum import AnEnum
 from ..models.different_enum import DifferentEnum
 from ..types import UNSET, Unset
@@ -17,12 +21,16 @@ class AModel:
     a_camel_date_time: Union[datetime.datetime, datetime.date]
     a_date: datetime.date
     required_not_nullable: str
+    model: AModelModel
     a_nullable_date: Optional[datetime.date]
     required_nullable: Optional[str]
+    nullable_model: Optional[AModelNullableModel]
     nested_list_of_enums: Union[Unset, List[List[DifferentEnum]]] = UNSET
     attr_1_leading_digit: Union[Unset, str] = UNSET
     not_required_nullable: Union[Unset, Optional[str]] = UNSET
     not_required_not_nullable: Union[Unset, str] = UNSET
+    not_required_model: Union[AModelNotRequiredModel, Unset] = UNSET
+    not_required_nullable_model: Union[Optional[AModelNotRequiredNullableModel], Unset] = UNSET
 
     def to_dict(self) -> Dict[str, Any]:
         an_enum_value = self.an_enum_value.value
@@ -35,6 +43,8 @@ class AModel:
 
         a_date = self.a_date.isoformat()
         required_not_nullable = self.required_not_nullable
+        model = self.model.to_dict()
+
         nested_list_of_enums: Union[Unset, List[Any]] = UNSET
         if not isinstance(self.nested_list_of_enums, Unset):
             nested_list_of_enums = []
@@ -52,6 +62,17 @@ class AModel:
         required_nullable = self.required_nullable
         not_required_nullable = self.not_required_nullable
         not_required_not_nullable = self.not_required_not_nullable
+        nullable_model = self.nullable_model.to_dict() if self.nullable_model else None
+
+        not_required_model: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.not_required_model, Unset):
+            not_required_model = self.not_required_model.to_dict()
+
+        not_required_nullable_model: Union[None, Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.not_required_nullable_model, Unset):
+            not_required_nullable_model = (
+                self.not_required_nullable_model.to_dict() if self.not_required_nullable_model else None
+            )
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(
@@ -60,8 +81,10 @@ class AModel:
                 "aCamelDateTime": a_camel_date_time,
                 "a_date": a_date,
                 "required_not_nullable": required_not_nullable,
+                "model": model,
                 "a_nullable_date": a_nullable_date,
                 "required_nullable": required_nullable,
+                "nullable_model": nullable_model,
             }
         )
         if nested_list_of_enums is not UNSET:
@@ -72,6 +95,10 @@ class AModel:
             field_dict["not_required_nullable"] = not_required_nullable
         if not_required_not_nullable is not UNSET:
             field_dict["not_required_not_nullable"] = not_required_not_nullable
+        if not_required_model is not UNSET:
+            field_dict["not_required_model"] = not_required_model
+        if not_required_nullable_model is not UNSET:
+            field_dict["not_required_nullable_model"] = not_required_nullable_model
 
         return field_dict
 
@@ -99,6 +126,8 @@ class AModel:
 
         required_not_nullable = d.pop("required_not_nullable")
 
+        model = AModelModel.from_dict(d.pop("model"))
+
         nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
         for nested_list_of_enums_item_data in _nested_list_of_enums or []:
@@ -124,17 +153,38 @@ class AModel:
 
         not_required_not_nullable = d.pop("not_required_not_nullable", UNSET)
 
+        nullable_model = None
+        _nullable_model = d.pop("nullable_model")
+        if _nullable_model is not None:
+            nullable_model = AModelNullableModel.from_dict(cast(Dict[str, Any], _nullable_model))
+
+        not_required_model: Union[AModelNotRequiredModel, Unset] = UNSET
+        _not_required_model = d.pop("not_required_model", UNSET)
+        if not isinstance(_not_required_model, Unset):
+            not_required_model = AModelNotRequiredModel.from_dict(cast(Dict[str, Any], _not_required_model))
+
+        not_required_nullable_model = None
+        _not_required_nullable_model = d.pop("not_required_nullable_model", UNSET)
+        if _not_required_nullable_model is not None and not isinstance(_not_required_nullable_model, Unset):
+            not_required_nullable_model = AModelNotRequiredNullableModel.from_dict(
+                cast(Dict[str, Any], _not_required_nullable_model)
+            )
+
         a_model = AModel(
             an_enum_value=an_enum_value,
             a_camel_date_time=a_camel_date_time,
             a_date=a_date,
             required_not_nullable=required_not_nullable,
+            model=model,
             nested_list_of_enums=nested_list_of_enums,
             a_nullable_date=a_nullable_date,
             attr_1_leading_digit=attr_1_leading_digit,
             required_nullable=required_nullable,
             not_required_nullable=not_required_nullable,
             not_required_not_nullable=not_required_not_nullable,
+            nullable_model=nullable_model,
+            not_required_model=not_required_model,
+            not_required_nullable_model=not_required_nullable_model,
         )
 
         return a_model

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_model = AModelModel(
+            a_property=a_property,
+        )
+
+        a_model_model.additional_properties = d
+        return a_model_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model_not_required_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model_not_required_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelNotRequiredModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelNotRequiredModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_not_required_model = AModelNotRequiredModel(
+            a_property=a_property,
+        )
+
+        a_model_not_required_model.additional_properties = d
+        return a_model_not_required_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model_not_required_nullable_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model_not_required_nullable_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelNotRequiredNullableModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelNotRequiredNullableModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_not_required_nullable_model = AModelNotRequiredNullableModel(
+            a_property=a_property,
+        )
+
+        a_model_not_required_nullable_model.additional_properties = d
+        return a_model_not_required_nullable_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model_nullable_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model_nullable_model.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Union
+
+import attr
+
+from ..models.an_enum import AnEnum
+from ..models.an_int_enum import AnIntEnum
+from ..types import UNSET, Unset
+
+
+@attr.s(auto_attribs=True)
+class AModelNullableModel:
+    """  """
+
+    a_property: Union[Unset, AnEnum, AnIntEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_property: Union[Unset, AnEnum, AnIntEnum]
+        if isinstance(self.a_property, Unset):
+            a_property = UNSET
+        elif isinstance(self.a_property, AnEnum):
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        else:
+            a_property = UNSET
+            if not isinstance(self.a_property, Unset):
+                a_property = self.a_property
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_property is not UNSET:
+            field_dict["a_property"] = a_property
+
+        return field_dict
+
+    @staticmethod
+    def from_dict(src_dict: Dict[str, Any]) -> "AModelNullableModel":
+        d = src_dict.copy()
+
+        def _parse_a_property(data: Any) -> Union[Unset, AnEnum, AnIntEnum]:
+            data = None if isinstance(data, Unset) else data
+            a_property: Union[Unset, AnEnum, AnIntEnum]
+            try:
+                a_property = UNSET
+                _a_property = data
+                if _a_property is not None:
+                    a_property = AnEnum(_a_property)
+
+                return a_property
+            except:  # noqa: E722
+                pass
+            a_property = UNSET
+            _a_property = data
+            if _a_property is not None:
+                a_property = AnIntEnum(_a_property)
+
+            return a_property
+
+        a_property = _parse_a_property(d.pop("a_property", UNSET))
+
+        a_model_nullable_model = AModelNullableModel(
+            a_property=a_property,
+        )
+
+        a_model_nullable_model.additional_properties = d
+        return a_model_nullable_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_primitive_additional_properties.py
@@ -33,7 +33,7 @@ class ModelWithPrimitiveAdditionalProperties:
         d = src_dict.copy()
         a_date_holder: Union[ModelWithPrimitiveAdditionalPropertiesADateHolder, Unset] = UNSET
         _a_date_holder = d.pop("a_date_holder", UNSET)
-        if _a_date_holder is not None and not isinstance(_a_date_holder, Unset):
+        if not isinstance(_a_date_holder, Unset):
             a_date_holder = ModelWithPrimitiveAdditionalPropertiesADateHolder.from_dict(
                 cast(Dict[str, Any], _a_date_holder)
             )

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -622,7 +622,7 @@
     "schemas": {
       "AModel": {
         "title": "AModel",
-        "required": ["an_enum_value", "aCamelDateTime", "a_date", "a_nullable_date", "required_nullable", "required_not_nullable"],
+        "required": ["an_enum_value", "aCamelDateTime", "a_date", "a_nullable_date", "required_nullable", "required_not_nullable", "model", "nullable_model"],
         "type": "object",
         "properties": {
           "an_enum_value": {
@@ -686,6 +686,42 @@
             "title": "NOT Required AND NOT Nullable",
             "type": "string",
             "nullable": false
+          },
+          "model": {
+            "type": "object",
+            "allOf": [
+              {
+                "ref": "#/components/schemas/ModelWithUnionProperty"
+              }
+            ],
+            "nullable": false
+          },
+          "nullable_model": {
+            "type": "object",
+            "allOf": [
+              {
+                "ref": "#/components/schemas/ModelWithUnionProperty"
+              }
+            ],
+            "nullable": true
+          },
+          "not_required_model": {
+            "type": "object",
+            "allOf": [
+              {
+                "ref": "#/components/schemas/ModelWithUnionProperty"
+              }
+            ],
+            "nullable": false
+          },
+          "not_required_nullable_model": {
+            "type": "object",
+            "allOf": [
+              {
+                "ref": "#/components/schemas/ModelWithUnionProperty"
+              }
+            ],
+            "nullable": true
           }
         },
         "description": "A Model for testing all the ways custom objects can be used ",

--- a/openapi_python_client/templates/property_templates/model_property.pyi
+++ b/openapi_python_client/templates/property_templates/model_property.pyi
@@ -1,5 +1,5 @@
 {% macro construct(property, source, initial_value=None) %}
-{% if property.required %}
+{% if property.required and not property.nullable %}
 {{ property.python_name }} = {{ property.reference.class_name }}.from_dict({{ source }})
 {% else %}
 {% if initial_value != None %}
@@ -10,7 +10,7 @@
 {{ property.python_name }}: {{ property.get_type_string() }} = UNSET
 {% endif %}
 _{{ property.python_name }} = {{source}}
-if _{{ property.python_name }} is not None and not isinstance(_{{ property.python_name }},  Unset):
+if {% if property.nullable %}_{{ property.python_name }} is not None{% endif %}{% if property.nullable and not property.required %} and {% endif %}{% if not property.required %}not isinstance(_{{ property.python_name }},  Unset){% endif %}:
     {{ property.python_name }} = {{ property.reference.class_name }}.from_dict(cast(Dict[str, Any], _{{ property.python_name }}))
 {% endif %}
 {% endmacro %}

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -176,7 +176,7 @@ def test_resolve_references_nested_allof(mocker):
                     ),
                 ]
             ),
-        }
+        },
     )
 
     components = {**schemas, "Model": model_schema}


### PR DESCRIPTION
Fixes the case when a model property is `nullable`, and adds E2E test coverage for this case.

I'm going to upstream this, but was planning to wait until https://github.com/triaxtec/openapi-python-client/pull/297 is merged (and didn't want to lump it into that PR to avoid scope creep).

Going to test by pulling this change into the `benchling-sdk` and confirming that integration tests pass (in particular for the `Container` and `Location` services).

Upstream PR: https://github.com/triaxtec/openapi-python-client/pull/315