### PR TITLE
feat: Serialize model query parameters with `style=form, explode=true` BNCH-18023

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/defaults_tests_defaults_post.py
@@ -13,6 +13,7 @@ from dateutil.parser import isoparse
 
 from ...models.an_enum import AnEnum
 from ...models.http_validation_error import HTTPValidationError
+from ...models.model_with_union_property import ModelWithUnionProperty
 from ...types import UNSET, Unset
 
 
@@ -50,6 +51,7 @@ def httpx_request(
     union_prop: Union[Unset, float, str] = "not a float",
     union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
+    model_prop: Union[ModelWithUnionProperty, Unset] = UNSET,
 ) -> Response[Union[None, HTTPValidationError]]:
 
     json_datetime_prop: Union[Unset, str] = UNSET
@@ -89,27 +91,33 @@ def httpx_request(
     if not isinstance(enum_prop, Unset):
         json_enum_prop = enum_prop
 
+    json_model_prop: Union[Unset, Dict[str, Any]] = UNSET
+    if not isinstance(model_prop, Unset):
+        json_model_prop = model_prop.to_dict()
+
     params: Dict[str, Any] = {}
-    if string_prop is not UNSET:
+    if not isinstance(string_prop, Unset) and string_prop is not None:
         params["string_prop"] = string_prop
-    if datetime_prop is not UNSET:
+    if not isinstance(json_datetime_prop, Unset) and json_datetime_prop is not None:
         params["datetime_prop"] = json_datetime_prop
-    if date_prop is not UNSET:
+    if not isinstance(json_date_prop, Unset) and json_date_prop is not None:
         params["date_prop"] = json_date_prop
-    if float_prop is not UNSET:
+    if not isinstance(float_prop, Unset) and float_prop is not None:
         params["float_prop"] = float_prop
-    if int_prop is not UNSET:
+    if not isinstance(int_prop, Unset) and int_prop is not None:
         params["int_prop"] = int_prop
-    if boolean_prop is not UNSET:
+    if not isinstance(boolean_prop, Unset) and boolean_prop is not None:
         params["boolean_prop"] = boolean_prop
-    if list_prop is not UNSET:
+    if not isinstance(json_list_prop, Unset) and json_list_prop is not None:
         params["list_prop"] = json_list_prop
-    if union_prop is not UNSET:
+    if not isinstance(json_union_prop, Unset) and json_union_prop is not None:
         params["union_prop"] = json_union_prop
-    if union_prop_with_ref is not UNSET:
+    if not isinstance(json_union_prop_with_ref, Unset) and json_union_prop_with_ref is not None:
         params["union_prop_with_ref"] = json_union_prop_with_ref
-    if enum_prop is not UNSET:
+    if not isinstance(json_enum_prop, Unset) and json_enum_prop is not None:
         params["enum_prop"] = json_enum_prop
+    if not isinstance(json_model_prop, Unset) and json_model_prop is not None:
+        params.update(json_model_prop)
 
     response = client.request(
         "post",

--- a/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/optional_value_tests_optional_query_param.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/api/tests/optional_value_tests_optional_query_param.py
@@ -44,7 +44,7 @@ def httpx_request(
         json_query_param = query_param
 
     params: Dict[str, Any] = {}
-    if query_param is not UNSET:
+    if not isinstance(json_query_param, Unset) and json_query_param is not None:
         params["query_param"] = json_query_param
 
     response = client.request(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -7,6 +7,7 @@ from dateutil.parser import isoparse
 from ...client import Client
 from ...models.an_enum import AnEnum
 from ...models.http_validation_error import HTTPValidationError
+from ...models.model_with_union_property import ModelWithUnionProperty
 from ...types import UNSET, Response, Unset
 
 
@@ -23,6 +24,7 @@ def _get_kwargs(
     union_prop: Union[Unset, float, str] = "not a float",
     union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
+    model_prop: Union[ModelWithUnionProperty, Unset] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/tests/defaults".format(client.base_url)
 
@@ -65,27 +67,33 @@ def _get_kwargs(
     if not isinstance(enum_prop, Unset):
         json_enum_prop = enum_prop
 
+    json_model_prop: Union[Unset, Dict[str, Any]] = UNSET
+    if not isinstance(model_prop, Unset):
+        json_model_prop = model_prop.to_dict()
+
     params: Dict[str, Any] = {}
-    if string_prop is not UNSET:
+    if not isinstance(string_prop, Unset) and string_prop is not None:
         params["string_prop"] = string_prop
-    if datetime_prop is not UNSET:
+    if not isinstance(json_datetime_prop, Unset) and json_datetime_prop is not None:
         params["datetime_prop"] = json_datetime_prop
-    if date_prop is not UNSET:
+    if not isinstance(json_date_prop, Unset) and json_date_prop is not None:
         params["date_prop"] = json_date_prop
-    if float_prop is not UNSET:
+    if not isinstance(float_prop, Unset) and float_prop is not None:
         params["float_prop"] = float_prop
-    if int_prop is not UNSET:
+    if not isinstance(int_prop, Unset) and int_prop is not None:
         params["int_prop"] = int_prop
-    if boolean_prop is not UNSET:
+    if not isinstance(boolean_prop, Unset) and boolean_prop is not None:
         params["boolean_prop"] = boolean_prop
-    if list_prop is not UNSET:
+    if not isinstance(json_list_prop, Unset) and json_list_prop is not None:
         params["list_prop"] = json_list_prop
-    if union_prop is not UNSET:
+    if not isinstance(json_union_prop, Unset) and json_union_prop is not None:
         params["union_prop"] = json_union_prop
-    if union_prop_with_ref is not UNSET:
+    if not isinstance(json_union_prop_with_ref, Unset) and json_union_prop_with_ref is not None:
         params["union_prop_with_ref"] = json_union_prop_with_ref
-    if enum_prop is not UNSET:
+    if not isinstance(json_enum_prop, Unset) and json_enum_prop is not None:
         params["enum_prop"] = json_enum_prop
+    if not isinstance(json_model_prop, Unset) and json_model_prop is not None:
+        params.update(json_model_prop)
 
     return {
         "url": url,
@@ -130,6 +138,7 @@ def sync_detailed(
     union_prop: Union[Unset, float, str] = "not a float",
     union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
+    model_prop: Union[ModelWithUnionProperty, Unset] = UNSET,
 ) -> Response[Union[None, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
@@ -143,6 +152,7 @@ def sync_detailed(
         union_prop=union_prop,
         union_prop_with_ref=union_prop_with_ref,
         enum_prop=enum_prop,
+        model_prop=model_prop,
     )
 
     response = httpx.post(
@@ -165,6 +175,7 @@ def sync(
     union_prop: Union[Unset, float, str] = "not a float",
     union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
+    model_prop: Union[ModelWithUnionProperty, Unset] = UNSET,
 ) -> Optional[Union[None, HTTPValidationError]]:
     """  """
 
@@ -180,6 +191,7 @@ def sync(
         union_prop=union_prop,
         union_prop_with_ref=union_prop_with_ref,
         enum_prop=enum_prop,
+        model_prop=model_prop,
     ).parsed
 
 
@@ -196,6 +208,7 @@ async def asyncio_detailed(
     union_prop: Union[Unset, float, str] = "not a float",
     union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
+    model_prop: Union[ModelWithUnionProperty, Unset] = UNSET,
 ) -> Response[Union[None, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
@@ -209,6 +222,7 @@ async def asyncio_detailed(
         union_prop=union_prop,
         union_prop_with_ref=union_prop_with_ref,
         enum_prop=enum_prop,
+        model_prop=model_prop,
     )
 
     async with httpx.AsyncClient() as _client:
@@ -230,6 +244,7 @@ async def asyncio(
     union_prop: Union[Unset, float, str] = "not a float",
     union_prop_with_ref: Union[Unset, float, AnEnum] = 0.6,
     enum_prop: Union[Unset, AnEnum] = UNSET,
+    model_prop: Union[ModelWithUnionProperty, Unset] = UNSET,
 ) -> Optional[Union[None, HTTPValidationError]]:
     """  """
 
@@ -246,5 +261,6 @@ async def asyncio(
             union_prop=union_prop,
             union_prop_with_ref=union_prop_with_ref,
             enum_prop=enum_prop,
+            model_prop=model_prop,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/optional_value_tests_optional_query_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/optional_value_tests_optional_query_param.py
@@ -21,7 +21,7 @@ def _get_kwargs(
         json_query_param = query_param
 
     params: Dict[str, Any] = {}
-    if query_param is not UNSET:
+    if not isinstance(json_query_param, Unset) and json_query_param is not None:
         params["query_param"] = json_query_param
 
     return {

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -396,6 +396,14 @@
             },
             "name": "enum_prop",
             "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ModelWithUnionProperty"
+            },
+            "name": "model_prop",
+            "in": "query"
           }
         ],
         "responses": {

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -27,6 +27,7 @@ class ModelProperty(Property):
     additional_properties: Union[bool, Property]
 
     template: ClassVar[str] = "model_property.pyi"
+    json_is_dict: ClassVar[bool] = True
 
     def resolve_references(
         self, components: Dict[str, Union[oai.Reference, oai.Schema]], schemas: Schemas

--- a/openapi_python_client/parser/properties/property.py
+++ b/openapi_python_client/parser/properties/property.py
@@ -28,6 +28,7 @@ class Property:
     python_name: str = attr.ib(init=False)
 
     template: ClassVar[Optional[str]] = None
+    json_is_dict: ClassVar[bool] = False
 
     def __attrs_post_init__(self) -> None:
         object.__setattr__(self, "python_name", utils.to_valid_python_identifier(utils.snake_case(self.name)))

--- a/openapi_python_client/templates/endpoint_macros.pyi
+++ b/openapi_python_client/templates/endpoint_macros.pyi
@@ -33,11 +33,12 @@ params: Dict[str, Any] = {
 }
     {% for property in endpoint.query_parameters %}
         {% if not property.required %}
-if {{ property.python_name }} is not UNSET:
-            {% if property.template %}
-    params["{{ property.name }}"] = {{ "json_" + property.python_name }}
+            {% set property_name = "json_" + property.python_name if property.template else property.python_name %}
+if {% if not property.required %}not isinstance({{ property_name }}, Unset) and {% endif %}{{ property_name }} is not None:
+            {% if property.json_is_dict %}
+    params.update({{ property_name }})
             {% else %}
-    params["{{ property.name }}"] = {{ property.python_name }}
+    params["{{ property.name }}"] = {{ property_name }}
             {% endif %}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
Fixes https://github.com/triaxtec/openapi-python-client/issues/295.

Upstream PR: https://github.com/triaxtec/openapi-python-client/pull/316

When I pulled this change into `openapi-specs` and made the changes in https://github.com/benchling/openapi-specs/pull/138, the generated code looked like this:

```
def _get_kwargs(
    *,
    client: Client,
    next_token: Union[Unset, None, str] = UNSET,
    page_size: Union[Unset, None, int] = 50,
    sort: Union[Unset, None, ListCustomEntitiesSort] = ListCustomEntitiesSort.MODIFIEDATDESC,
    modified_at: Union[Unset, None, str] = UNSET,
    name: Union[Unset, None, str] = UNSET,
    name_includes: Union[Unset, None, str] = UNSET,
    folder_id: Union[Unset, None, str] = UNSET,
    mentioned_in: Union[Unset, None, List[str]] = UNSET,
    project_id: Union[Unset, None, str] = UNSET,
    registry_id: Union[Unset, None, str] = UNSET,
    schema_id: Union[Unset, None, str] = UNSET,
    schema_field: Union[Unset, None, ListCustomEntitiesSchemaField] = UNSET,
    archive_reason: Union[Unset, None, str] = UNSET,
    mentions: Union[Unset, None, List[str]] = UNSET,
    ids: Union[Unset, None, str] = UNSET,
    entity_registry_idsany_of: Union[Unset, None, str] = UNSET,
) -> Dict[str, Any]:
    url = "{}/custom-entities".format(client.base_url)

    headers: Dict[str, Any] = client.get_headers()

    json_sort: Union[Unset, None, int] = UNSET
    if not isinstance(sort, Unset):
        json_sort = sort.value if sort else None

    json_mentioned_in: Union[Unset, None, List[Any]] = UNSET
    if not isinstance(mentioned_in, Unset):
        if mentioned_in is None:
            json_mentioned_in = None
        else:
            json_mentioned_in = mentioned_in

    json_schema_field: Union[Unset, None, Dict[str, Any]] = UNSET
    if not isinstance(schema_field, Unset):
        json_schema_field = schema_field.to_dict() if schema_field else None

    json_mentions: Union[Unset, None, List[Any]] = UNSET
    if not isinstance(mentions, Unset):
        if mentions is None:
            json_mentions = None
        else:
            json_mentions = mentions

    params: Dict[str, Any] = {}
    if not isinstance(next_token, Unset) and next_token is not None:
        params["nextToken"] = next_token
    if not isinstance(page_size, Unset) and page_size is not None:
        params["pageSize"] = page_size
    if not isinstance(json_sort, Unset) and json_sort is not None:
        params["sort"] = json_sort
    if not isinstance(modified_at, Unset) and modified_at is not None:
        params["modifiedAt"] = modified_at
    if not isinstance(name, Unset) and name is not None:
        params["name"] = name
    if not isinstance(name_includes, Unset) and name_includes is not None:
        params["nameIncludes"] = name_includes
    if not isinstance(folder_id, Unset) and folder_id is not None:
        params["folderId"] = folder_id
    if not isinstance(json_mentioned_in, Unset) and json_mentioned_in is not None:
        params["mentionedIn"] = json_mentioned_in
    if not isinstance(project_id, Unset) and project_id is not None:
        params["projectId"] = project_id
    if not isinstance(registry_id, Unset) and registry_id is not None:
        params["registryId"] = registry_id
    if not isinstance(schema_id, Unset) and schema_id is not None:
        params["schemaId"] = schema_id
    if not isinstance(json_schema_field, Unset) and json_schema_field is not None:
        params.update(json_schema_field)
    if not isinstance(archive_reason, Unset) and archive_reason is not None:
        params["archiveReason"] = archive_reason
    if not isinstance(json_mentions, Unset) and json_mentions is not None:
        params["mentions"] = json_mentions
    if not isinstance(ids, Unset) and ids is not None:
        params["ids"] = ids
    if not isinstance(entity_registry_idsany_of, Unset) and entity_registry_idsany_of is not None:
        params["entityRegistryIds.anyOf"] = entity_registry_idsany_of

    return {
        "url": url,
        "headers": headers,
        "cookies": client.get_cookies(),
        "timeout": client.get_timeout(),
        "params": params,
    }
```

This should allow us to do schema field queries with by passing in a dict
```
{
	"schemaField.field1": "value1",
	"schemaField.field2": "value2",
}
```