### PR TITLE
fix: Generate parameters to generated client without adding None BNCH-22940

### DIFF
--- a/openapi_python_client/parser/properties/property.py
+++ b/openapi_python_client/parser/properties/property.py
@@ -62,11 +62,7 @@ class Property:
             if self.nullable:
                 return f"Union[Unset, None, {type_string}]"
             else:
-                if query_parameter:
-                    # For query parameters, None has the same meaning as Unset
-                    return f"Union[Unset, None, {type_string}]"
-                else:
-                    return f"Union[Unset, {type_string}]"
+                return f"Union[Unset, {type_string}]"
 
     def get_instance_type_string(self) -> str:
         """Get a string representation of runtime type that should be used for `isinstance` checks"""

--- a/openapi_python_client/templates/property_templates/date_property.pyi
+++ b/openapi_python_client/templates/property_templates/date_property.pyi
@@ -17,7 +17,7 @@ if _{{ property.python_name }} is not None:
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(query_parameter=query_parameter, json=True) }}{% endif %} = UNSET
 if not isinstance({{ source }}, Unset):
-{% if property.nullable or query_parameter %}
+{% if property.nullable %}
     {{ destination }} = {{ source }}.isoformat() if {{ source }} else None
 {% else %}
     {{ destination }} = {{ source }}.isoformat()

--- a/openapi_python_client/templates/property_templates/datetime_property.pyi
+++ b/openapi_python_client/templates/property_templates/datetime_property.pyi
@@ -26,7 +26,7 @@ if _{{ property.python_name }} is not None:
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(query_parameter=query_parameter, json=True) }}{% endif %} = UNSET
 if not isinstance({{ source }}, Unset):
-{% if property.nullable or query_parameter %}
+{% if property.nullable %}
     {{ destination }} = {{ source }}.isoformat() if {{ source }} else None
 {% else %}
     {{ destination }} = {{ source }}.isoformat()

--- a/openapi_python_client/templates/property_templates/enum_property.pyi
+++ b/openapi_python_client/templates/property_templates/enum_property.pyi
@@ -21,7 +21,7 @@ if _{{ property.python_name }} is not None and _{{ property.python_name }} is no
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(query_parameter=query_parameter, json=True) }}{% endif %} = UNSET
 if not isinstance({{ source }}, Unset):
-{% if property.nullable or query_parameter %}
+{% if property.nullable %}
     {{ destination }} = {{ source }}.value if {{ source }} else None
 {% else %}
     {{ destination }} = {{ source }}.value

--- a/openapi_python_client/templates/property_templates/file_property.pyi
+++ b/openapi_python_client/templates/property_templates/file_property.pyi
@@ -16,7 +16,7 @@
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(query_parameter=query_parameter, json=True) }}{% endif %} = UNSET
 if not isinstance({{ source }}, Unset):
-{% if property.nullable or query_parameter %}
+{% if property.nullable %}
     {{ destination }} = {{ source }}.to_tuple() if {{ source }} else None
 {% else %}
     {{ destination }} = {{ source }}.to_tuple()

--- a/openapi_python_client/templates/property_templates/list_property.pyi
+++ b/openapi_python_client/templates/property_templates/list_property.pyi
@@ -48,7 +48,7 @@ else:
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(query_parameter=query_parameter, json=True) }}{% endif %} = UNSET
 if not isinstance({{ source }}, Unset):
-{% if property.nullable or query_parameter %}
+{% if property.nullable %}
     if {{ source }} is None:
         {{ destination }} = None
     else:

--- a/openapi_python_client/templates/property_templates/model_property.pyi
+++ b/openapi_python_client/templates/property_templates/model_property.pyi
@@ -27,7 +27,7 @@ if {% if property.nullable %}_{{ property.python_name }} is not None{% endif %}{
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(query_parameter=query_parameter, json=True) }}{% endif %} = UNSET
 if not isinstance({{ source }}, Unset):
-{% if property.nullable or query_parameter %}
+{% if property.nullable %}
     {{ destination }} = {{ source }}.to_dict() if {{ source }} else None
 {% else %}
     {{ destination }} = {{ source }}.to_dict()

--- a/openapi_python_client/templates/property_templates/union_property.pyi
+++ b/openapi_python_client/templates/property_templates/union_property.pyi
@@ -45,7 +45,7 @@ def _parse_{{ property.python_name }}(data: {{ property.get_type_string(json=Tru
 if isinstance({{ source }}, Unset):
     {{ destination }} = UNSET
 {% endif %}
-{% if property.nullable or (query_parameter and not property.required) %}
+{% if property.nullable %}
     {% if property.required %}
 if {{ source }} is None:
     {% else %}{# There's an if UNSET statement before this #}


### PR DESCRIPTION
Upstream generates the client this way, and in a parallel benchling-sdk ticket we'll be doing a conversion to UNSET for None parameters in the service layer.  Making this change in the fork in the meantime will keep us in a good state.