### PR TITLE
Allow Client to ignore lower specified timeout values

### DIFF
--- a/end_to_end_tests/golden-record-custom/custom_e2e/client.py
+++ b/end_to_end_tests/golden-record-custom/custom_e2e/client.py
@@ -30,9 +30,15 @@ class Client:
     def get_timeout(self) -> float:
         return self.timeout
 
-    def with_timeout(self, timeout: float) -> "Client":
-        """ Get a new client matching this one with a new timeout (in seconds) """
-        return attr.evolve(self, timeout=timeout)
+    def with_timeout(self, timeout: float, override_lower_default: bool = True) -> "Client":
+        """ Get a new client matching this one with a new timeout (in seconds)
+
+        To ignore the specified timeout value if it's lower than the default
+        timeout in the client, set override_lower_default=False
+        """
+        if override_lower_default or timeout > self.timeout:
+            return attr.evolve(self, timeout=timeout)
+        return self
 
 
 @attr.s(auto_attribs=True)

--- a/end_to_end_tests/golden-record/my_test_api_client/client.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/client.py
@@ -30,9 +30,15 @@ class Client:
     def get_timeout(self) -> float:
         return self.timeout
 
-    def with_timeout(self, timeout: float) -> "Client":
-        """ Get a new client matching this one with a new timeout (in seconds) """
-        return attr.evolve(self, timeout=timeout)
+    def with_timeout(self, timeout: float, override_lower_default: bool = True) -> "Client":
+        """ Get a new client matching this one with a new timeout (in seconds)
+
+        To ignore the specified timeout value if it's lower than the default
+        timeout in the client, set override_lower_default=False
+        """
+        if override_lower_default or timeout > self.timeout:
+            return attr.evolve(self, timeout=timeout)
+        return self
 
 
 @attr.s(auto_attribs=True)

--- a/openapi_python_client/templates/client.pyi
+++ b/openapi_python_client/templates/client.pyi
@@ -29,9 +29,15 @@ class Client:
     def get_timeout(self) -> float:
         return self.timeout
 
-    def with_timeout(self, timeout: float) -> "Client":
-        """ Get a new client matching this one with a new timeout (in seconds) """
-        return attr.evolve(self, timeout=timeout)
+    def with_timeout(self, timeout: float, override_lower_default: bool = True) -> "Client":
+        """ Get a new client matching this one with a new timeout (in seconds)
+
+        To ignore the specified timeout value if it's lower than the default
+        timeout in the client, set override_lower_default=False
+        """
+        if override_lower_default or timeout > self.timeout:
+            return attr.evolve(self, timeout=timeout)
+        return self
 
 @attr.s(auto_attribs=True)
 class AuthenticatedClient(Client):


### PR DESCRIPTION
Allows a `Client` returned from `with_timeout()` to discard the specified `timeout` if it's lower than the client's existing timeout by setting `override_lower_default=False`. Most commonly users are intending to set a higher timeout for specific calls, but in some cases they end up lowering the timeout if a high default was already unknowingly set.

`override_lower_default` is set to `True` to preserve backwards compatibility, which will exhibit the existing behavior of always setting the `timeout`.