### PR TITLE
feat: Add description to Property definitions BNCH-29178

### DIFF
--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -239,6 +239,7 @@ def _string_based_property(
             required=required,
             default=convert("datetime.datetime", data.default),
             nullable=data.nullable,
+            description=data.description,
         )
     elif string_format == "date":
         return DateProperty(
@@ -246,6 +247,7 @@ def _string_based_property(
             required=required,
             default=convert("datetime.date", data.default),
             nullable=data.nullable,
+            description=data.description,
         )
     elif string_format == "binary":
         return FileProperty(
@@ -253,6 +255,7 @@ def _string_based_property(
             required=required,
             default=None,
             nullable=data.nullable,
+            description=data.description,
         )
     else:
         return StringProperty(
@@ -261,6 +264,7 @@ def _string_based_property(
             required=required,
             pattern=data.pattern,
             nullable=data.nullable,
+            description=data.description,
         )
 
 
@@ -414,6 +418,7 @@ def build_enum_property(
         reference=reference,
         values=values,
         value_type=value_type,
+        description=data.description,
     )
     schemas = attr.evolve(schemas, enums={**schemas.enums, prop.reference.class_name: prop})
     return prop, schemas
@@ -439,6 +444,7 @@ def build_union_property(
             default=default,
             inner_properties=sub_properties,
             nullable=data.nullable,
+            description=data.description,
         ),
         schemas,
     )
@@ -461,6 +467,7 @@ def build_list_property(
             default=None,
             inner_property=inner_prop,
             nullable=data.nullable,
+            description=data.description,
         ),
         schemas,
     )
@@ -517,6 +524,7 @@ def _property_from_data(
                 default=convert("float", data.default),
                 required=required,
                 nullable=data.nullable,
+                description=data.description,
             ),
             schemas,
         )
@@ -527,6 +535,7 @@ def _property_from_data(
                 default=convert("int", data.default),
                 required=required,
                 nullable=data.nullable,
+                description=data.description,
             ),
             schemas,
         )
@@ -537,6 +546,7 @@ def _property_from_data(
                 required=required,
                 default=convert("bool", data.default),
                 nullable=data.nullable,
+                description=data.description,
             ),
             schemas,
         )
@@ -545,7 +555,13 @@ def _property_from_data(
     elif data.type == "object" or data.allOf:
         return build_model_property(data=data, name=name, schemas=schemas, required=required, parent_name=parent_name)
     elif not data.type:
-        return NoneProperty(name=name, required=required, nullable=False, default=None), schemas
+        return NoneProperty(
+            name=name,
+            required=required,
+            nullable=False,
+            default=None,
+            description=data.description
+        ), schemas
     return PropertyError(data=data, detail=f"unknown type {data.type}"), schemas
 
 

--- a/openapi_python_client/parser/properties/property.py
+++ b/openapi_python_client/parser/properties/property.py
@@ -27,6 +27,7 @@ class Property:
     _json_type_string: ClassVar[str] = ""  # Type of the property after JSON serialization
     default: Optional[str] = attr.ib()
     python_name: str = attr.ib(init=False)
+    description: Optional[str]
 
     template: ClassVar[Optional[str]] = None
     json_is_dict: ClassVar[bool] = False

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -28,7 +28,7 @@ _SOURCE_BY_CONTENT_TYPE = {
 def empty_response(status_code: int, response_name: str) -> Response:
     return Response(
         status_code=status_code,
-        prop=NoneProperty(name=response_name, default=None, nullable=False, required=True),
+        prop=NoneProperty(name=response_name, default=None, nullable=False, required=True, description=None),
         source="None",
     )
 


### PR DESCRIPTION
To enable adding docstrings to python members in a generated way from the OpenAPI spec, add the description member to `Property` objects (which have been already parsed by the generator just not included in templates).

This is used in a corresponding change in benchling-sdk.