### PR TITLE
fix: `null` in openapi enums breaks client generation BNCH-32257

### DIFF
--- a/openapi_python_client/parser/properties/enum_property.py
+++ b/openapi_python_client/parser/properties/enum_property.py
@@ -50,7 +50,9 @@ class EnumProperty(Property):
                 else:
                     output[f"VALUE_{value}"] = value
                 continue
-            if value[0].isalpha():
+            if value is None:
+                continue
+            if value and value[0].isalpha():
                 key = value.upper()
             else:
                 key = f"VALUE_{i}"

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -456,7 +456,7 @@ class TestEnumProperty:
     def test_values_from_list(self):
         from openapi_python_client.parser.properties import EnumProperty
 
-        data = ["abc", "123", "a23", "1bc", 4, -3, "a Thing WIth spaces"]
+        data = ["abc", "123", "a23", "1bc", 4, -3, "a Thing WIth spaces", "", None]
 
         result = EnumProperty.values_from_list(data)
 
@@ -468,6 +468,7 @@ class TestEnumProperty:
             "VALUE_4": 4,
             "VALUE_NEGATIVE_3": -3,
             "A_THING_WITH_SPACES": "a Thing WIth spaces",
+            "VALUE_7": "",
         }
 
     def test_values_from_list_duplicate(self):


### PR DESCRIPTION
OpenAPI specifies that if an enum is nullable, to specify - null in the list of possible items. This manifests as None when parsed in Python, and the parser tries to create a member in the enum class for it. This fails because it attempts to convert it to uppercase, and it's not a string, but None shouldn't get an enum value NULL or NONE anyway, because the client code would just pass None instead of EnumProperty.NONE for a nullable enum.

This change makes a change to support empty strings as well, mirroring the fix in upstream: https://github.com/openapi-generators/openapi-python-client/pull/358/files