### PR TITLE
bugfix:broader attrs dependencies BNCH-36541

### DIFF
--- a/openapi_python_client/templates/pyproject.toml
+++ b/openapi_python_client/templates/pyproject.toml
@@ -15,7 +15,7 @@ include = ["CHANGELOG.md", "{{ package_name }}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.6"
 httpx = "^0.15.0"
-attrs = "^20.1.0"
+attrs = ">=20.1.0, <22.0"
 python-dateutil = "^2.8.0"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ isort = "^5.0.5"
 pyyaml = "^5.3.1"
 importlib_metadata = {version = "^2.0.0", python = "<3.8"}
 pydantic = "^1.6.1"
-attrs = "^20.1.0"
+attrs = ">=20.1.0, <22.0"
 python-dateutil = "^2.8.1"
 httpx = ">=0.15.4,<0.17.0"
 autoflake = "^1.4"


### PR DESCRIPTION
Loosen the pinned `attrs` dependency

see also: [corresponding PR in benchling-sdk](https://github.com/benchling/benchling-sdk/pull/231)

**Testing**
Generate and test `benchling_api_client`