### PR TITLE
chore: Bump up httpx in template / generated pyproject.yaml BNCH-38599

### DIFF
--- a/openapi_python_client/templates/pyproject.toml
+++ b/openapi_python_client/templates/pyproject.toml
@@ -14,7 +14,7 @@ include = ["CHANGELOG.md", "{{ package_name }}/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-httpx = "^0.15.0"
+httpx = ">=0.15.4, <=0.22.0"
 attrs = ">=20.1.0, <22.0"
 python-dateutil = "^2.8.0"
 


### PR DESCRIPTION
Complements #115 to also bump up the dependency in the generated client (really, this is the only bump we needed).