### PR TITLE
fix: support $ref from endpoint response to components/responses BNCH-109662

### DIFF
--- a/end_to_end_tests/baseline_openapi_3.0.json
+++ b/end_to_end_tests/baseline_openapi_3.0.json
@@ -991,6 +991,20 @@
         }
       }
     },
+    "/responses/reference": {
+      "get": {
+        "tags": [
+          "responses"
+        ],
+        "summary": "Endpoint using predefined response",
+        "operationId": "reference_response",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/AResponse"
+          }
+        }
+      }
+    },
     "/auth/token_with_cookie": {
       "get": {
         "tags": [
@@ -2922,6 +2936,18 @@
         "$ref": "#/components/requestBodies/ARequestBody"
       },
       "ARequestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AModel"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "AResponse": {
+        "description": "OK",
         "content": {
           "application/json": {
             "schema": {

--- a/end_to_end_tests/baseline_openapi_3.1.yaml
+++ b/end_to_end_tests/baseline_openapi_3.1.yaml
@@ -983,6 +983,20 @@ info:
       }
     }
   },
+  "/responses/reference": {
+    "get": {
+      "tags": [
+        "responses"
+      ],
+      "summary": "Endpoint using predefined response",
+      "operationId": "reference_response",
+      "responses": {
+        "200": {
+          "$ref": "#/components/responses/AResponse"
+        }
+      }
+    }
+  },
   "/auth/token_with_cookie": {
     "get": {
       "tags": [
@@ -2917,6 +2931,13 @@ info:
     NestedRef:
       "$ref": "#/components/requestBodies/ARequestBody"
     ARequestBody:
+      content:
+        "application/json":
+          "schema":
+            "$ref": "#/components/schemas/AModel"
+  responses:
+    AResponse:
+      description: OK
       content:
         "application/json":
           "schema":

--- a/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/responses/__init__.py
+++ b/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/responses/__init__.py
@@ -2,7 +2,7 @@
 
 import types
 
-from . import post_responses_unions_simple_before_complex, text_response
+from . import post_responses_unions_simple_before_complex, reference_response, text_response
 
 
 class ResponsesEndpoints:
@@ -19,3 +19,10 @@ class ResponsesEndpoints:
         Text Response
         """
         return text_response
+
+    @classmethod
+    def reference_response(cls) -> types.ModuleType:
+        """
+        Endpoint using predefined response
+        """
+        return reference_response

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/reference_response.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/reference_response.py
@@ -1,0 +1,122 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.a_model import AModel
+from ...types import Response
+
+
+def _get_kwargs() -> Dict[str, Any]:
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/responses/reference",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[AModel]:
+    if response.status_code == 200:
+        response_200 = AModel.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[AModel]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[AModel]:
+    """Endpoint using predefined response
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AModel]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[AModel]:
+    """Endpoint using predefined response
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AModel
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[AModel]:
+    """Endpoint using predefined response
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[AModel]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[AModel]:
+    """Endpoint using predefined response
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        AModel
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/openapi_python_client/parser/bodies.py
+++ b/openapi_python_client/parser/bodies.py
@@ -9,6 +9,7 @@ from openapi_python_client.parser.properties import (
     Schemas,
     property_from_data,
 )
+from openapi_python_client.parser.properties.schemas import get_reference_simple_name
 
 from .. import schema as oai
 from ..config import Config
@@ -138,7 +139,7 @@ def _resolve_reference(
     references_seen = []
     while isinstance(body, oai.Reference) and body.ref not in references_seen:
         references_seen.append(body.ref)
-        body = request_bodies.get(body.ref.split("/")[-1])
+        body = request_bodies.get(get_reference_simple_name(body.ref))
     if isinstance(body, oai.Reference):
         return ParseError(detail="Circular $ref in request body", data=body)
     if body is None and references_seen:

--- a/openapi_python_client/parser/properties/schemas.py
+++ b/openapi_python_client/parser/properties/schemas.py
@@ -46,6 +46,13 @@ def parse_reference_path(ref_path_raw: str) -> Union[ReferencePath, ParseError]:
     return cast(ReferencePath, parsed.fragment)
 
 
+def get_reference_simple_name(ref_path: str) -> str:
+    """
+    Takes a path like `/components/schemas/NameOfThing` and returns a string like `NameOfThing`.
+    """
+    return ref_path.split("/", 3)[-1]
+
+
 @define
 class Class:
     """Represents Python class which will be generated from an OpenAPI schema"""
@@ -56,7 +63,7 @@ class Class:
     @staticmethod
     def from_string(*, string: str, config: Config) -> "Class":
         """Get a Class from an arbitrary string"""
-        class_name = string.split("/")[-1]  # Get rid of ref path stuff
+        class_name = get_reference_simple_name(string)  # Get rid of ref path stuff
         class_name = ClassName(class_name, config.field_prefix)
         override = config.class_overrides.get(class_name)
 

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple, TypedDict, Union
 from attrs import define
 
 from openapi_python_client import utils
-from openapi_python_client.parser.properties.schemas import parse_reference_path
+from openapi_python_client.parser.properties.schemas import get_reference_simple_name, parse_reference_path
 
 from .. import Config
 from .. import schema as oai
@@ -98,7 +98,7 @@ def response_from_data(  # noqa: PLR0911
             return ref_path, schemas
         if not ref_path.startswith("/components/responses/"):
             return ParseError(data=data, detail=f"$ref to {data.ref} not allowed in responses"), schemas
-        resp_data = responses.get(ref_path.split("/")[-1], None)
+        resp_data = responses.get(get_reference_simple_name(ref_path), None)
         if not resp_data:
             return ParseError(data=data, detail=f"Could not find reference: {data.ref}"), schemas
         if not isinstance(resp_data, oai.Response):

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -80,7 +80,7 @@ def empty_response(
     )
 
 
-def response_from_data(
+def response_from_data(  # noqa: PLR0911
     *,
     status_code: HTTPStatus,
     data: Union[oai.Response, oai.Reference],

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -85,7 +85,9 @@ class TestEndpoint:
         response_from_data = mocker.patch(f"{MODULE_NAME}.response_from_data", return_value=(parse_error, schemas))
         config = MagicMock()
 
-        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas, responses={}, config=config)
+        response, schemas = Endpoint._add_responses(
+            endpoint=endpoint, data=data, schemas=schemas, responses={}, config=config
+        )
 
         assert response.errors == [
             ParseError(
@@ -110,12 +112,28 @@ class TestEndpoint:
         response_from_data = mocker.patch(f"{MODULE_NAME}.response_from_data", return_value=(parse_error, schemas))
         config = MagicMock()
 
-        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas, responses={}, config=config)
+        response, schemas = Endpoint._add_responses(
+            endpoint=endpoint, data=data, schemas=schemas, responses={}, config=config
+        )
 
         response_from_data.assert_has_calls(
             [
-                mocker.call(status_code=200, data=response_1_data, schemas=schemas, responses={}, parent_name="name", config=config),
-                mocker.call(status_code=404, data=response_2_data, schemas=schemas, responses={}, parent_name="name", config=config),
+                mocker.call(
+                    status_code=200,
+                    data=response_1_data,
+                    schemas=schemas,
+                    responses={},
+                    parent_name="name",
+                    config=config,
+                ),
+                mocker.call(
+                    status_code=404,
+                    data=response_2_data,
+                    schemas=schemas,
+                    responses={},
+                    parent_name="name",
+                    config=config,
+                ),
             ]
         )
         assert response.errors == [

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -85,7 +85,7 @@ class TestEndpoint:
         response_from_data = mocker.patch(f"{MODULE_NAME}.response_from_data", return_value=(parse_error, schemas))
         config = MagicMock()
 
-        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas, config=config)
+        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas, responses={}, config=config)
 
         assert response.errors == [
             ParseError(
@@ -110,12 +110,12 @@ class TestEndpoint:
         response_from_data = mocker.patch(f"{MODULE_NAME}.response_from_data", return_value=(parse_error, schemas))
         config = MagicMock()
 
-        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas, config=config)
+        response, schemas = Endpoint._add_responses(endpoint=endpoint, data=data, schemas=schemas, responses={}, config=config)
 
         response_from_data.assert_has_calls(
             [
-                mocker.call(status_code=200, data=response_1_data, schemas=schemas, parent_name="name", config=config),
-                mocker.call(status_code=404, data=response_2_data, schemas=schemas, parent_name="name", config=config),
+                mocker.call(status_code=200, data=response_1_data, schemas=schemas, responses={}, parent_name="name", config=config),
+                mocker.call(status_code=404, data=response_2_data, schemas=schemas, responses={}, parent_name="name", config=config),
             ]
         )
         assert response.errors == [
@@ -474,6 +474,7 @@ class TestEndpoint:
             method=method,
             tag="default",
             schemas=initial_schemas,
+            responses={},
             parameters=parameters,
             config=config,
             request_bodies={},
@@ -509,6 +510,7 @@ class TestEndpoint:
             method=method,
             tag="default",
             schemas=initial_schemas,
+            responses={},
             parameters=initial_parameters,
             config=config,
             request_bodies={},
@@ -549,6 +551,7 @@ class TestEndpoint:
             method=method,
             tag="default",
             schemas=initial_schemas,
+            responses={},
             parameters=initial_parameters,
             config=config,
             request_bodies={},
@@ -570,7 +573,7 @@ class TestEndpoint:
             config=config,
         )
         _add_responses.assert_called_once_with(
-            endpoint=param_endpoint, data=data.responses, schemas=param_schemas, config=config
+            endpoint=param_endpoint, data=data.responses, schemas=param_schemas, responses={}, config=config
         )
 
     def test_from_data_no_operation_id(self, mocker, config):
@@ -600,6 +603,7 @@ class TestEndpoint:
             method=method,
             tag="default",
             schemas=schemas,
+            responses={},
             parameters=parameters,
             config=config,
             request_bodies={},
@@ -624,6 +628,7 @@ class TestEndpoint:
             endpoint=add_parameters.return_value[0],
             data=data.responses,
             schemas=add_parameters.return_value[1],
+            responses={},
             config=config,
         )
 
@@ -654,6 +659,7 @@ class TestEndpoint:
             method=method,
             tag="a",
             schemas=schemas,
+            responses={},
             parameters=parameters,
             config=config,
             request_bodies={},
@@ -678,6 +684,7 @@ class TestEndpoint:
             endpoint=add_parameters.return_value[0],
             data=data.responses,
             schemas=add_parameters.return_value[1],
+            responses={},
             config=config,
         )
 
@@ -693,6 +700,7 @@ class TestEndpoint:
                 ),
             ),
             schemas=Schemas(),
+            responses={},
             config=config,
             parameters=Parameters(),
             tag="tag",
@@ -716,6 +724,7 @@ class TestEndpoint:
                 ),
             ),
             schemas=Schemas(),
+            responses={},
             config=config,
             parameters=Parameters(),
             tag="tag",
@@ -787,6 +796,7 @@ class TestEndpointCollection:
             parameters=Parameters(),
             config=config,
             request_bodies={},
+            responses={},
         )
         collection: EndpointCollection = collections["default"]
         assert isinstance(collection.endpoints[0].query_parameters[0], IntProperty)
@@ -825,6 +835,7 @@ class TestEndpointCollection:
             config=config,
             parameters=parameters,
             request_bodies={},
+            responses={},
         )
 
         assert result["default"].parse_errors[0].data == "1"
@@ -866,7 +877,7 @@ class TestEndpointCollection:
         parameters = mocker.MagicMock()
 
         result = EndpointCollection.from_data(
-            data=data, schemas=schemas, parameters=parameters, config=config, request_bodies={}
+            data=data, schemas=schemas, parameters=parameters, config=config, request_bodies={}, responses={}
         )
 
         assert result == (

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -184,14 +184,14 @@ def test_response_from_data_reference(mocker, any_property_factory):
 
 
 @pytest.mark.parametrize(
-    "ref_string",
+    "ref_string,expected_error_string",
     [
-        "#/components/responses/Nonexistent",
-        "malformed-references-string",
-        "#/components/something-that-isnt-responses/ErrorResponse",
+        ("#/components/responses/Nonexistent", "Could not find"),
+        ("https://remote-reference", "Remote references"),
+        ("#/components/something-that-isnt-responses/ErrorResponse", "not allowed in responses"),
     ],
 )
-def test_response_from_data_reference_errors(ref_string, mocker, any_property_factory):
+def test_response_from_data_invalid_reference(ref_string, expected_error_string, mocker, any_property_factory):
     from openapi_python_client.parser import responses
 
     prop = any_property_factory()
@@ -213,6 +213,38 @@ def test_response_from_data_reference_errors(ref_string, mocker, any_property_fa
     )
 
     assert isinstance(response, ParseError)
+    assert expected_error_string in response.detail
+
+
+def test_response_from_data_ref_to_response_that_is_a_ref(mocker, any_property_factory):
+    from openapi_python_client.parser import responses
+
+    prop = any_property_factory()
+    mocker.patch.object(responses, "property_from_data", return_value=(prop, Schemas()))
+    predefined_response_base_data = oai.Response.model_construct(
+        description="",
+        content={"application/json": oai.MediaType.model_construct(media_type_schema="something")},
+    )
+    predefined_response_data = oai.Reference.model_construct(
+        ref="#/components/references/BaseResponse",
+    )
+    config = MagicMock()
+    config.content_type_overrides = {}
+
+    response, schemas = responses.response_from_data(
+        status_code=400,
+        data=oai.Reference.model_construct(ref="#/components/schemas/ErrorResponse"),
+        schemas=Schemas(),
+        responses={
+            "BaseResponse": predefined_response_base_data,
+            "ErrorResponse": predefined_response_data,
+        },
+        parent_name="parent",
+        config=config,
+    )
+
+    assert isinstance(response, ParseError)
+    assert "not allowed in responses" in response.detail
 
 
 def test_response_from_data_content_type_overrides(any_property_factory):

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -233,7 +233,7 @@ def test_response_from_data_ref_to_response_that_is_a_ref(mocker, any_property_f
 
     response, schemas = responses.response_from_data(
         status_code=400,
-        data=oai.Reference.model_construct(ref="#/components/schemas/ErrorResponse"),
+        data=oai.Reference.model_construct(ref="#/components/responses/ErrorResponse"),
         schemas=Schemas(),
         responses={
             "BaseResponse": predefined_response_base_data,
@@ -244,7 +244,7 @@ def test_response_from_data_ref_to_response_that_is_a_ref(mocker, any_property_f
     )
 
     assert isinstance(response, ParseError)
-    assert "not allowed in responses" in response.detail
+    assert "Top-level $ref" in response.detail
 
 
 def test_response_from_data_content_type_overrides(any_property_factory):

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -17,6 +17,7 @@ def test_response_from_data_no_content(any_property_factory):
         status_code=200,
         data=data,
         schemas=Schemas(),
+        responses={},
         parent_name="parent",
         config=MagicMock(),
     )
@@ -34,31 +35,6 @@ def test_response_from_data_no_content(any_property_factory):
     )
 
 
-def test_response_from_data_reference(any_property_factory):
-    from openapi_python_client.parser.responses import Response, response_from_data
-
-    data = oai.Reference.model_construct()
-
-    response, schemas = response_from_data(
-        status_code=200,
-        data=data,
-        schemas=Schemas(),
-        parent_name="parent",
-        config=MagicMock(),
-    )
-
-    assert response == Response(
-        status_code=200,
-        prop=any_property_factory(
-            name="response_200",
-            default=None,
-            required=True,
-        ),
-        source=NONE_SOURCE,
-        data=data,
-    )
-
-
 def test_response_from_data_unsupported_content_type():
     from openapi_python_client.parser.responses import response_from_data
 
@@ -69,6 +45,7 @@ def test_response_from_data_unsupported_content_type():
         status_code=200,
         data=data,
         schemas=Schemas(),
+        responses={},
         parent_name="parent",
         config=config,
     )
@@ -89,6 +66,7 @@ def test_response_from_data_no_content_schema(any_property_factory):
         status_code=200,
         data=data,
         schemas=Schemas(),
+        responses={},
         parent_name="parent",
         config=config,
     )
@@ -121,6 +99,7 @@ def test_response_from_data_property_error(mocker):
         status_code=400,
         data=data,
         schemas=Schemas(),
+        responses={},
         parent_name="parent",
         config=config,
     )
@@ -152,6 +131,7 @@ def test_response_from_data_property(mocker, any_property_factory):
         status_code=400,
         data=data,
         schemas=Schemas(),
+        responses={},
         parent_name="parent",
         config=config,
     )
@@ -172,6 +152,35 @@ def test_response_from_data_property(mocker, any_property_factory):
     )
 
 
+def test_response_from_data_reference(mocker, any_property_factory):
+    from openapi_python_client.parser import responses
+
+    prop = any_property_factory()
+    mocker.patch.object(responses, "property_from_data", return_value=(prop, Schemas()))
+    predefined_response_data = oai.Response.model_construct(
+        description="",
+        content={"application/json": oai.MediaType.model_construct(media_type_schema="something")},
+    )
+    config = MagicMock()
+    config.content_type_overrides = {}
+
+    response, schemas = responses.response_from_data(
+        status_code=400,
+        data=oai.Reference.model_construct(ref="#/components/responses/ErrorResponse"),
+        schemas=Schemas(),
+        responses={"ErrorResponse": predefined_response_data},
+        parent_name="parent",
+        config=config,
+    )
+
+    assert response == responses.Response(
+        status_code=400,
+        prop=prop,
+        source=JSON_SOURCE,
+        data=predefined_response_data,
+    )
+
+
 def test_response_from_data_content_type_overrides(any_property_factory):
     from openapi_python_client.parser.responses import Response, response_from_data
 
@@ -185,6 +194,7 @@ def test_response_from_data_content_type_overrides(any_property_factory):
         status_code=200,
         data=data,
         schemas=Schemas(),
+        responses={},
         parent_name="parent",
         config=config,
     )


### PR DESCRIPTION
Fixes https://github.com/openapi-generators/openapi-python-client/issues/1125.

I've also opened a PR from the same branch in the upstream repo ([here](https://github.com/openapi-generators/openapi-python-client/pull/1148)), but here I'm targeting it to our fork repo in against a new `2.x` branch (which I created by pulling the latest release code on `main` from the upstream repo). The `main` branch in our fork repo is still the same as it was, that is, a heavily modified fork of a very old version of the upstream repo.

See also: https://benchling.atlassian.net/wiki/spaces/AE/pages/730268159/Fixes+necessary+to+use+openapi-python-client+for+v3+API

**Why we need this fix:** The V3 API spec makes heavy use of reusable response definitions like this, so that we don't have to spell out the same standard error responses for every endpoint.

This makes it so the following—
```yaml
components:
  responses:
    GoodResponse:
      description: OK
      content:
        "application/json":
          schema:
            $ref: "#/components/schemas/MyObject"

paths:
  "/endpoint":
    get:
      responses:
        "200":
          $ref: "#/components/responses/GoodResponse"
```

—is exactly equivalent to:
```yaml
paths:
  "/endpoint":
    get:
      responses:
        "200":
          description: OK
          content:
            "application/json":
              schema:
                $ref: "#/components/schemas/MyObject"
```

Previously, it would have failed to follow the response reference and behaved as if the response had no content.

This still requires the response to be fully defined inline in `components/responses`; it can't itself consist of just a `$ref`.