### PR TITLE
eng: fix package ID & description - BNCH-112051

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
     "ruff>=0.2,<0.8",
     "typing-extensions>=4.8.0,<5.0.0",
 ]
-name = "openapi-python-client"
+name = "benchling-openapi-python-client"
 version = "2.0.0-alpha.1"
-description = "Generate modern Python clients from OpenAPI"
+description = "Generate modern Python clients from OpenAPI (Benchling fork)"
 keywords = [
     "OpenAPI",
     "Client",


### PR DESCRIPTION
This change is only for Benchling's internal use of the package and will not be submitted to the upstream repo.

It updates the package name to the same one used by our earlier fork. We will just be publishing a higher major version of that package.