### PR TITLE
eng: add build-system config for package BNCH-112051

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 # This fork of openapi-python-client is published internally at Benchling. Changes in this
 # project file will *not* be contributed upstream.
 
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "benchling-openapi-python-client"
 version = "2.0.0-alpha.1"


### PR DESCRIPTION
This change is only for Benchling's internal use of the package and will not be submitted to the upstream repo. It's another prerequisite for us to be able to publish versions of the prod/2.x fork.

Basically, I forgot that our package-publishing pipeline uses a generic build frontend (`python -m build`) and needs a config hint as to which package management tool we're using, in this case poetry. I tested this change by running `python -m build` locally and it built a package.