### PR TITLE
eng: fix forward type reference in Pydantic schemas BNCH-112697

### DIFF
--- a/openapi_python_client/schema/openapi_schema_pydantic/header.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/header.py
@@ -29,3 +29,10 @@ class Header(Parameter):
             ]
         },
     )
+
+
+# Calling model_rebuild() here helps Pydantic to resolve the forward references that were used
+# in defining Parameter and Encoding. Without this call, any subtle change to the loading order
+# of schema submodules could result in an error like "Parameter is not fully defined".
+# See: https://docs.pydantic.dev/latest/concepts/models/#rebuilding-model-schema
+Parameter.model_rebuild()


### PR DESCRIPTION
This fixes what I _think_ is arguably a bug in the upstream code, but one that I've never reproduced until now and still can't reproduce in any simple automated test. I was only able to reproduce it by testing with one particular large API spec file—but not all the time. I don't understand the reason for this indeterminacy, but I do think I understand the error.

The code generator is using Pydantic as a validation framework for the OpenAPI schema (that is, the schema of OpenAPI itself, not of our API). There is a class derived from Pydantic's `BaseModel` for every standard OpenAPI component. In one area of OpenAPI, there is a circular reference: an `Encoding` can contain a `Header`, which can contain a `MediaType`, which can contain an `Encoding`.

Pydantic does support using forward references to represent something like this; accordingly, the definition of `Encoding` references `Header` by name ("Header") instead of importing the type. According to the Pydantic docs, this can work transparently in some cases—`Encoding` should be able to lazily resolve that reference, once `Header` has actually been defined. And it seems that that was working fine before. But the logic behind the lazy resolving is [extremely complicated](https://docs.pydantic.dev/latest/internals/resolving_annotations/#resolving-annotations-when-rebuilding-a-model) and it seems that in some hard-to-define cases, you may need to give it an assist by calling `.model_resolve()` on the class that had the forward reference. So that's what I've added here. It's what [the docs](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_rebuild) advise you to do if all else fails, and as far as I can tell it has no negative effects on anything.

To be clear, I had never changed _any_ of the code in this `.openapi_pydantic_schema` module in our fork. Whatever is happening differently inside Pydantic must be a side effect of some interaction between my code changes in other files and the specific data in this one API document, which maybe caused modules to be loaded in a different order or something like that.

I will also submit this change upstream, although I don't know if they'll accept it since I have no idea how to write a test for it.