### PR TITLE
eng: add option to put docstrings on model attributes BNCH-114718

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ class_overrides:
 
 The easiest way to find what needs to be overridden is probably to generate your client and go look at everything in the `models` folder.
 
+### docstrings_on_attributes
+
+By default, when `openapi-python-client` generates a model class, it includes a list of attributes and their
+descriptions in the docstring for the class. If you set this option to `true`, then the attribute descriptions
+will be put in docstrings for the attributes themselves, and will not be in the class docstring.
+
+```yaml
+docstrings_on_attributes: true
+```
+
 ### literal_enums
 
 By default, `openapi-python-client` generates classes inheriting for `Enum` for enums. It can instead use `Literal` 

--- a/end_to_end_tests/functional_tests/generated_code_execution/test_docstrings.py
+++ b/end_to_end_tests/functional_tests/generated_code_execution/test_docstrings.py
@@ -1,9 +1,11 @@
+import re
 from typing import Any, List
 
 from end_to_end_tests.functional_tests.helpers import (
     with_generated_code_import,
     with_generated_client_fixture,
 )
+from end_to_end_tests.generated_client import GeneratedClientContext
 
 
 class DocstringParser:
@@ -36,16 +38,55 @@ components:
       required: ["reqStr", "undescribedProp"]
 """)
 @with_generated_code_import(".models.MyModel")
-class TestSchemaDocstrings:
+class TestSchemaDocstringsDefaultBehavior:
     def test_model_description(self, MyModel):
         assert DocstringParser(MyModel).lines[0] == "I like this type."
 
-    def test_model_properties(self, MyModel):
+    def test_model_properties_in_model_description(self, MyModel):
         assert set(DocstringParser(MyModel).get_section("Attributes:")) == {
             "req_str (str): This is necessary.",
             "opt_str (Union[Unset, str]): This isn't necessary.",
             "undescribed_prop (str):",
         }
+
+
+@with_generated_client_fixture(
+"""
+components:
+  schemas:
+    MyModel:
+      description: I like this type.
+      type: object
+      properties:
+        prop1:
+          type: string
+          description: This attribute has a description
+        prop2:
+          type: string  # no description for this one
+      required: ["prop1", "prop2"]
+""",
+config="docstrings_on_attributes: true",
+)
+@with_generated_code_import(".models.MyModel")
+class TestSchemaWithDocstringsOnAttributesOption:
+    def test_model_description_is_entire_docstring(self, MyModel):
+        assert MyModel.__doc__.strip() == "I like this type."
+
+    def test_attrs_have_docstrings(self, generated_client: GeneratedClientContext):
+        # A docstring that appears after an attribute is *not* stored in __doc__ anywhere
+        # by the interpreter, so we can't inspect it that way-- but it's still valid for it
+        # to appear there, and it will be recognized by documentation tools. So we'll assert
+        # that these strings appear in the source code. The code should look like this:
+        #     class MyModel:
+        #         """I like this type."
+        #         prop1: str
+        #         """This attribute has a description"
+        #         prop2: str
+        # 
+        source_file_path = generated_client.output_path / generated_client.base_module / "models" / "my_model.py"
+        content = source_file_path.read_text()
+        assert re.search('\n *prop1: *str\n *""" *This attribute has a description *"""\n', content)
+        assert re.search('\n *prop2: *str\n *[^"]', content)
 
 
 @with_generated_client_fixture(

--- a/end_to_end_tests/functional_tests/generated_code_execution/test_docstrings.py
+++ b/end_to_end_tests/functional_tests/generated_code_execution/test_docstrings.py
@@ -78,9 +78,9 @@ class TestSchemaWithDocstringsOnAttributesOption:
         # to appear there, and it will be recognized by documentation tools. So we'll assert
         # that these strings appear in the source code. The code should look like this:
         #     class MyModel:
-        #         """I like this type."
+        #         """I like this type."""
         #         prop1: str
-        #         """This attribute has a description"
+        #         """This attribute has a description"""
         #         prop2: str
         # 
         source_file_path = generated_client.output_path / generated_client.base_module / "models" / "my_model.py"

--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -95,6 +95,7 @@ class Project:
 
         self.env.filters.update(TEMPLATE_FILTERS)
         self.env.globals.update(
+            config=config,
             utils=utils,
             python_identifier=lambda x: utils.PythonIdentifier(x, config.field_prefix),
             class_name=lambda x: utils.ClassName(x, config.field_prefix),

--- a/openapi_python_client/config.py
+++ b/openapi_python_client/config.py
@@ -41,6 +41,7 @@ class ConfigFile(BaseModel):
     package_version_override: Optional[str] = None
     use_path_prefixes_for_title_model_names: bool = True
     post_hooks: Optional[list[str]] = None
+    docstrings_on_attributes: bool = False
     field_prefix: str = "field_"
     generate_all_tags: bool = False
     http_timeout: int = 5
@@ -70,6 +71,7 @@ class Config:
     package_version_override: Optional[str]
     use_path_prefixes_for_title_model_names: bool
     post_hooks: list[str]
+    docstrings_on_attributes: bool
     field_prefix: str
     generate_all_tags: bool
     http_timeout: int
@@ -111,6 +113,7 @@ class Config:
             package_version_override=config_file.package_version_override,
             use_path_prefixes_for_title_model_names=config_file.use_path_prefixes_for_title_model_names,
             post_hooks=post_hooks,
+            docstrings_on_attributes=config_file.docstrings_on_attributes,
             field_prefix=config_file.field_prefix,
             generate_all_tags=config_file.generate_all_tags,
             http_timeout=config_file.http_timeout,

--- a/openapi_python_client/templates/client.py.jinja
+++ b/openapi_python_client/templates/client.py.jinja
@@ -5,6 +5,31 @@ from attrs import define, field, evolve
 import httpx
 
 
+{% set attrs_info = {
+    "raise_on_unexpected_status": namespace(
+        type="bool",
+        default="field(default=False, kw_only=True)",
+        docstring="Whether or not to raise an errors.UnexpectedStatus if the API returns a status code"
+            " that was not documented in the source OpenAPI document. Can also be provided as a keyword"
+            " argument to the constructor."
+    ),
+    "token": namespace(type="str", default="", docstring="The token to use for authentication"),
+    "prefix": namespace(type="str", default='"Bearer"', docstring="The prefix to use for the Authorization header"),
+    "auth_header_name": namespace(type="str", default='"Authorization"', docstring="The name of the Authorization header"),
+} %}
+
+{% macro attr_in_class_docstring(name) %}
+{{ name }}: {{ attrs_info[name].docstring }}
+{%- endmacro %}
+
+{% macro declare_attr(name) %}
+{% set attr = attrs_info[name] %}
+{{ name }}: {{ attr.type }}{% if attr.default %} = {{ attr.default }}{% endif %}
+{% if attr.docstring and config.docstrings_on_attributes +%}
+"""{{ attr.docstring }}"""
+{%- endif %}
+{% endmacro %}
+
 @define
 class Client:
     """A class for keeping track of data related to the API
@@ -29,14 +54,14 @@ class Client:
         ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
 {% endmacro %}
 {{ httpx_args_docstring() }}
+{% if not config.docstrings_on_attributes %}
 
     Attributes:
-        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
-            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
-            argument to the constructor.
+        {{ attr_in_class_docstring("raise_on_unexpected_status") | wordwrap(101) | indent(12) }}
+{% endif %}
     """
 {% macro attributes() %}
-    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    {{ declare_attr("raise_on_unexpected_status") | indent(4) }}
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
     _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
@@ -147,20 +172,20 @@ class AuthenticatedClient:
     """A Client which has been authenticated for use on secured endpoints
 
 {{ httpx_args_docstring() }}
+{% if not config.docstrings_on_attributes %}
 
     Attributes:
-        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
-            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
-            argument to the constructor.
-        token: The token to use for authentication
-        prefix: The prefix to use for the Authorization header
-        auth_header_name: The name of the Authorization header
+        {{ attr_in_class_docstring("raise_on_unexpected_status") | wordwrap(101) | indent(12) }}
+        {{ attr_in_class_docstring("token") | indent(8) }}
+        {{ attr_in_class_docstring("prefix") | indent(8) }}
+        {{ attr_in_class_docstring("auth_header_name") | indent(8) }}
+{% endif %}
     """
 
 {{ attributes() }}
-    token: str
-    prefix: str = "Bearer"
-    auth_header_name: str = "Authorization"
+    {{ declare_attr("token") | indent(4) }}
+    {{ declare_attr("prefix") | indent(4) }}
+    {{ declare_attr("auth_header_name") | indent(4) }}
 
 {{ builders("AuthenticatedClient") }}
 {{ httpx_stuff("AuthenticatedClient", "self._headers[self.auth_header_name] = f\"{self.prefix} {self.token}\" if self.prefix else self.token") }}

--- a/openapi_python_client/templates/helpers.jinja
+++ b/openapi_python_client/templates/helpers.jinja
@@ -1,8 +1,10 @@
-{% macro safe_docstring(content) %}
+{% macro safe_docstring(content, omit_if_empty=False) %}
 {# This macro returns the provided content as a docstring, set to a raw string if it contains a backslash #}
+{% if (not omit_if_empty) or (content | trim) %}
 {% if '\\' in content -%}
 r""" {{ content }} """
 {%- else -%}
 """ {{ content }} """
 {%- endif -%}
+{% endif %}
 {% endmacro %}

--- a/openapi_python_client/templates/model.py.jinja
+++ b/openapi_python_client/templates/model.py.jinja
@@ -47,25 +47,34 @@ T = TypeVar("T", bound="{{ class_name }}")
         {{ model.example | string | wordwrap(112) | indent(12) }}
 
     {% endif %}
-    {% if model.required_properties or model.optional_properties %}
+    {% if (not config.docstrings_on_attributes) and (model.required_properties or model.optional_properties) %}
     Attributes:
     {% for property in model.required_properties + model.optional_properties %}
         {{ property.to_docstring() | wordwrap(112) | indent(12) }}
     {% endfor %}{% endif %}
 {% endmacro %}
 
+{% macro declare_property(property) %}
+{%- if config.docstrings_on_attributes and property.description -%}
+{{ property.to_string() }}
+{{ safe_docstring(property.description, omit_if_empty=True) | wordwrap(112) }}
+{%- else -%}
+{{ property.to_string() }}
+{%- endif -%}
+{% endmacro %}
+
 @_attrs_define
 class {{ class_name }}:
-    {{ safe_docstring(class_docstring_content(model)) | indent(4) }}
+    {{ safe_docstring(class_docstring_content(model), omit_if_empty=config.docstrings_on_attributes) | indent(4) }}
 
     {% for property in model.required_properties + model.optional_properties %}
     {% if property.default is none and property.required %}
-    {{ property.to_string() }}
+    {{ declare_property(property) | indent(4) }}
     {% endif %}
     {% endfor %}
     {% for property in model.required_properties + model.optional_properties %}
     {% if property.default is not none or not property.required %}
-    {{ property.to_string() }}
+    {{ declare_property(property) | indent(4) }}
     {% endif %}
     {% endfor %}
     {% if model.additional_properties %}


### PR DESCRIPTION
This PR is for the Benchling fork. There is an equivalent upstream PR, https://github.com/openapi-generators/openapi-python-client/pull/1190 - see the description there for more details.

The implementation here is exactly equivalent to the upstream PR, so will not change if that one is accepted. There is a difference in the test code: this PR uses the "functional tests" mechanism that exists on our fork, rather than the "golden record" type of test which is the only way to test it upstream.

## Why we need this

The tool's current behavior is to make a docstring for each model class that combines the schema-level description with a list of all the properties and their types and descriptions. It ends up looking like this:

```python
class BenchlingAlignedSequence
    """
    An aligned sequence within a NucleotideAlignment

    Attributes:
        field_typename (Union[Unset, str]):
        bases (Union[None, Unset, str]): The bases of the Aligned Sequence, including gaps.
        name (Union[None, Unset, str]): The name of the Aligned Sequence.
        pairwise_identity (Union[None, Unset, float]): Fraction of bases between trimStart and trimEnd that match the
            template bases. Only present for Template Alignments; Will be empty for Consensus Alignments.
    """

    field_typename: Union[Unset, str]
    bases: Union[None, Unset, str]
    name: Union[None, Unset, str]
    pairwise_identity: Union[None, Unset, float]
```

That's nice enough if you're just looking directly at the source code— but it's pretty bad if you plan to use a documentation tool like Sphinx, as we do. The use of line breaks and indents in the "Attributes:" section confuses these tools, if they try to interpret it as any kind of markup— it's not valid in Sphinx's `.rst` format, and it's not valid in Markdown either. So you end up seeing something like this:

<img width="657" alt="image" src="https://github.com/user-attachments/assets/5002d871-61fe-4e76-8013-bc8c1563c0c3" />

Plus, as you can see in the code example, putting the type signatures of the attributes into the docstring is redundant: they already have type hints in the code, which documentation tools and IDEs already know how to parse.

So, by using the new option in this PR, we can make the code look like this instead:

```python
class BenchlingAlignedSequence
    """
    An aligned sequence within a NucleotideAlignment
    """

    field_typename: Union[Unset, str]
    bases: Union[None, Unset, str]
    """The bases of the Aligned Sequence, including gaps."""
    name: Union[None, Unset, str]
    """The name of the Aligned Sequence."""
    pairwise_identity: Union[None, Unset, float]
    """Fraction of bases between trimStart and trimEnd that match the template bases. Only present for Template Alignments; Will be empty for Consensus Alignments."""
```

This renders nicely in Sphinx, and the attribute descriptions also show up if you hover over an attribute in VS Code.

(The way we used to deal with this in our old SDK was somewhat different: we had heavily customized the generator's template for model classes, so that instead of just declaring attributes and letting `attrs` auto-generate everything, we were creating custom getter methods and putting docstrings on those. We'd like to avoid doing anything like that in the future; making custom versions of complex generator templates made our code very hard to maintain.)