### PR TITLE
app: Respect `required` field in parameters included with $ref BNCH-126490

### DIFF
--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -27,7 +27,7 @@ else:
 # Benchling renames the package to avoid publishing naming collision
 # This can lead to importlib.metadata.PackageNotFoundError: openapi_python_client
 try:
-    __version__ = version(__package__)
+    __version__ = version("benchling_openapi_python_client")
 except Exception:
     pass
 

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -5,8 +5,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from pydantic import ValidationError
 
-from .properties.schemas import Parameters, parameter_from_reference
-
 from .. import schema as oai
 from .. import utils
 from .errors import GeneratorError, ParseError, PropertyError
@@ -19,6 +17,7 @@ from .properties import (
     build_schemas,
     property_from_data,
 )
+from .properties.schemas import Parameters, parameter_from_reference
 from .reference import Reference
 from .responses import Response, response_from_data
 

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -700,9 +700,7 @@ def build_parameters(
             if isinstance(ref_path, ParseError):
                 parameters.errors.append(ParameterError(detail=ref_path.detail, data=data))
                 continue
-            parameters_or_err = update_parameters_with_data(
-                ref_path=ref_path, data=data, parameters=parameters
-            )
+            parameters_or_err = update_parameters_with_data(ref_path=ref_path, data=data, parameters=parameters)
             if isinstance(parameters_or_err, ParameterError):
                 next_round.append((name, data))
                 errors.append(parameters_or_err)

--- a/openapi_python_client/parser/properties/schemas.py
+++ b/openapi_python_client/parser/properties/schemas.py
@@ -7,10 +7,9 @@ import attr
 
 from ... import schema as oai
 from ...schema.parameter import Parameter
-
+from ...utils import ClassName
 from ..errors import ParameterError, ParseError
 from .enum_property import EnumProperty
-from ...utils import ClassName
 from .model_property import ModelProperty
 
 ReferencePath = NewType("ReferencePath", str)

--- a/openapi_python_client/parser/properties/schemas.py
+++ b/openapi_python_client/parser/properties/schemas.py
@@ -50,7 +50,6 @@ class Parameters:
 def parameter_from_data(
     *,
     name: str,
-    required: bool,
     data: Union[oai.Reference, oai.Parameter],
     parameters: Parameters,
 ) -> Tuple[Union[Parameter, ParameterError], Parameters]:
@@ -64,7 +63,7 @@ def parameter_from_data(
 
     new_param = Parameter(
         name=name,
-        required=required,
+        required=data.required,
         explode=data.explode,
         style=data.style,
         param_schema=data.param_schema,
@@ -91,7 +90,7 @@ def update_parameters_with_data(
     See Also:
         - https://swagger.io/docs/specification/using-ref/
     """
-    param, parameters = parameter_from_data(data=data, name=data.name, parameters=parameters, required=True)
+    param, parameters = parameter_from_data(data=data, name=data.name, parameters=parameters)
 
     if isinstance(param, ParameterError):
         param.detail = f"{param.header}: {param.detail}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "openapi-python-client"
+name = "benchling-openapi-python-client"
 # Our versions have diverged and have no relation to upstream code changes
 # Henceforth, benchling-openapi-python-package will be maintained internally
 version = "1.0.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "benchling-openapi-python-client"
 # Our versions have diverged and have no relation to upstream code changes
 # Henceforth, benchling-openapi-python-package will be maintained internally
-version = "1.0.7"
+version = "1.0.8"
 description = "Generate modern Python clients from OpenAPI"
 repository = "https://github.com/benchling/openapi-python-client"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "benchling-openapi-python-client"
+name = "openapi-python-client"
 # Our versions have diverged and have no relation to upstream code changes
 # Henceforth, benchling-openapi-python-package will be maintained internally
 version = "1.0.7"

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -1,7 +1,7 @@
-from openapi_python_client.parser.properties.schemas import Parameters, ReferencePath
 import openapi_python_client.schema as oai
 from openapi_python_client import GeneratorError
 from openapi_python_client.parser.errors import ParseError
+from openapi_python_client.parser.properties.schemas import Parameters, ReferencePath
 
 MODULE_NAME = "openapi_python_client.parser.openapi"
 


### PR DESCRIPTION
## Description
Use the actual `required` annotation from referenced parameter, rather than forcing it to `True`. Duh.

## Additional context

Most of this change is fixing minor breakages from the past couple PRs:
- Run isort and black, which I didn't do after #231
- Use the new package name in the weird __version__ import statement, so unit tests pass under poetry. Didn't catch this in the previous change because it was a direct commit to the branch.